### PR TITLE
Map pub srv

### DIFF
--- a/fiducial_slam/CMakeLists.txt
+++ b/fiducial_slam/CMakeLists.txt
@@ -10,8 +10,31 @@ find_package(catkin REQUIRED COMPONENTS
    tf2_msgs
    geometry_msgs
    sensor_msgs
-   visualization_msgs)
+   visualization_msgs
+   message_generation
+)
 
+##############
+## Messages ##
+##############
+
+add_message_files(
+   FILES
+   FiducialMapEntry.msg
+   FiducialMapEntryArray.msg
+)
+
+
+##############
+## Services ##
+##############
+
+add_service_files(
+  FILES
+  InitializeMap.srv
+)
+
+generate_messages()
 catkin_package()
 
 #############

--- a/fiducial_slam/CMakeLists.txt
+++ b/fiducial_slam/CMakeLists.txt
@@ -46,7 +46,7 @@ install(DIRECTORY launch/
 )
 
 catkin_install_python(PROGRAMS scripts/move_origin.py scripts/init_map.py
-        nodes/init_amcl.py nodes/fiducial_slam.py
+        nodes/init_amcl.py nodes/fiducial_slam_node.py
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -44,10 +44,10 @@ Default `true`.
 * `/fiducials` A topic of `visualization_msgs/Marker` messages that can be viewed
 in rviz for debugging.
 
-* `/fiducial_pose` a topic of `geometry_msgs/PoseWithCovarianceStamped` containing
+* `/fiducial_pose` A topic of `geometry_msgs/PoseWithCovarianceStamped` containing
 the computed pose.
 
-*  `/fiducial_map`  a topic of `fiducial_slam/FiducialMapEntryArray` containing
+*  `/fiducial_map`  A topic of `fiducial_slam/FiducialMapEntryArray` containing
 the current state of the map.
 
 * `tf` Transforms

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -47,7 +47,8 @@ in rviz for debugging.
 * `/fiducial_pose` a topic of `geometry_msgs/PoseWithCovarianceStamped` containing
 the computed pose.
 
-*  /fiducial_map  fiducial_slam/FiducialMapEntryArray
+*  /fiducial_map  a topic of `fiducial_slam/FiducialMapEntryArray` containing
+the current state of the map.
 
 * `tf` Transforms
 
@@ -61,5 +62,4 @@ fiducial pose.
 
 ### Services
 
-*  /initialize_fiducial_map  Clears the map and reinitializes it with the contents of the specified
-fiducial_slam/FiducialMapEntryArray.
+*  /initialize_fiducial_map  Clears the map and reinitializes it with the contents of the specified `fiducial_slam/FiducialMapEntryArray`.

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -47,7 +47,7 @@ in rviz for debugging.
 * `/fiducial_pose` a topic of `geometry_msgs/PoseWithCovarianceStamped` containing
 the computed pose.
 
-*  /fiducial_map  a topic of `fiducial_slam/FiducialMapEntryArray` containing
+*  `/fiducial_map`  a topic of `fiducial_slam/FiducialMapEntryArray` containing
 the current state of the map.
 
 * `tf` Transforms

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -50,7 +50,7 @@ the computed pose.
 *  `/fiducial_map`  A topic of `fiducial_slam/FiducialMapEntryArray` containing
 the current state of the map.
 
-* `tf` Transforms
+* `/tf` Transforms
 
 
 ### Subscribed Topics

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -62,4 +62,4 @@ fiducial pose.
 
 ### Services
 
-*  /initialize_fiducial_map  Clears the map and reinitializes it with the contents of the specified `fiducial_slam/FiducialMapEntryArray`.
+*  `/initialize_fiducial_map` Clears the map and reinitializes it with the contents of the specified `fiducial_slam/FiducialMapEntryArray`.

--- a/fiducial_slam/README.md
+++ b/fiducial_slam/README.md
@@ -1,4 +1,4 @@
-## fiducial_slam fiducial_slam.py
+## fiducial_slam fiducial_slam_node.py
 
 This node performs 3D Simultaneous Localization and Mapping (SLAM) from the 
 fiducial transforms. For the mapping part, pairs of transforms are combined
@@ -47,6 +47,8 @@ in rviz for debugging.
 * `/fiducial_pose` a topic of `geometry_msgs/PoseWithCovarianceStamped` containing
 the computed pose.
 
+*  /fiducial_map  fiducial_slam/FiducialMapEntryArray
+
 * `tf` Transforms
 
 
@@ -56,3 +58,8 @@ the computed pose.
 fiducial pose.
 
 * `/tf` Transforms
+
+### Services
+
+*  /initialize_fiducial_map  Clears the map and reinitializes it with the contents of the specified
+fiducial_slam/FiducialMapEntryArray.

--- a/fiducial_slam/launch/fiducial_slam.launch
+++ b/fiducial_slam/launch/fiducial_slam.launch
@@ -11,7 +11,7 @@
   <arg name="future" default="0.0"/>
 
 
-  <node type="fiducial_slam.py" pkg="fiducial_slam" output="screen" name="fiducial_slam">
+  <node type="fiducial_slam_node.py" pkg="fiducial_slam" output="screen" name="fiducial_slam">
     <param name="map_file" value="$(env HOME)/.ros/slam/map.txt" />
     <param name="obs_file" value="$(env HOME)/.ros/slam/obs.txt" />
     <param name="trans_file" value="$(env HOME)/.ros/slam/trans.txt" />

--- a/fiducial_slam/msg/FiducialMapEntry.msg
+++ b/fiducial_slam/msg/FiducialMapEntry.msg
@@ -1,0 +1,11 @@
+# pose of a fiducial
+int32 fiducial_id
+# translation
+float64 x
+float64 y
+float64 z
+# rotation
+float64 rx
+float64 ry
+float64 rz
+

--- a/fiducial_slam/msg/FiducialMapEntryArray.msg
+++ b/fiducial_slam/msg/FiducialMapEntryArray.msg
@@ -1,0 +1,1 @@
+FiducialMapEntry[] fiducials

--- a/fiducial_slam/srv/InitializeMap.srv
+++ b/fiducial_slam/srv/InitializeMap.srv
@@ -1,0 +1,2 @@
+FiducialMapEntryArray fiducials
+---

--- a/fiducial_slam/test/ceiling_test_2.xml
+++ b/fiducial_slam/test/ceiling_test_2.xml
@@ -17,7 +17,7 @@
     <remap from="/camera_info" to="/raspicam_node/camera_info"/>
   </node>
 
-  <node type="fiducial_slam.py" pkg="fiducial_slam" name="fiducial_slam">
+  <node type="fiducial_slam_node.py" pkg="fiducial_slam" name="fiducial_slam">
     <param name="initial_map_file" value="$(find fiducial_slam)/test/initial_map2.txt" />
     <param name="map_file" value="$(find fiducial_slam)/test/map2.txt" />
     <param name="obs_file" value="$(find fiducial_slam)/test/obs.txt" />

--- a/fiducial_slam/test/create_map.xml
+++ b/fiducial_slam/test/create_map.xml
@@ -8,7 +8,7 @@
   <node name="camera_pose" pkg="tf2_ros" type="static_transform_publisher" 
         args="0.0 0.0 0.0 0.0 0.0 0.0 0.0 base_link raspicam" />
 
-  <node type="fiducial_slam.py" pkg="fiducial_slam" name="fiducial_slam">
+  <node type="fiducial_slam_node.py" pkg="fiducial_slam" name="fiducial_slam">
     <param name="initial_map_file" value="$(find fiducial_slam)/test/610_initial_map.txt" />
     <param name="map_file" value="$(find fiducial_slam)/test/map.txt" />
     <param name="obs_file" value="$(find fiducial_slam)/test/obs.txt" />

--- a/fiducial_slam/test/localization.test
+++ b/fiducial_slam/test/localization.test
@@ -14,7 +14,7 @@
     <remap from="/camera_info" to="/camera_info"/>
   </node>
 
-  <node type="fiducial_slam.py" pkg="fiducial_slam" name="fiducial_slam">
+  <node type="fiducial_slam_node.py" pkg="fiducial_slam" name="fiducial_slam">
     <param name="initial_map_file" value="$(find fiducial_slam)/test/initial_map.txt" />
     <param name="map_file" value="/tmp/test/map.txt" />
     <param name="obs_file" value="/tmp/test/obs.txt" />


### PR DESCRIPTION
Note that it was necessary to rename fiducial_slam.py to be different from the package name, so the new generated Python for msgs and srv could be imported.