### PR TITLE
Handle bad camera_info messages

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -238,7 +238,7 @@ void FiducialsNode::camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg
         return;
     }
 
-    if (msg->distortion_model != "") {
+    if (msg->K != boost::array<double, 9>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0})) {
         for (int i=0; i<3; i++) {
             for (int j=0; j<3; j++) {
                 cameraMatrix.at<double>(i, j) = msg->K[i*3+j];
@@ -253,7 +253,7 @@ void FiducialsNode::camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg
         frameId = msg->header.frame_id;
     }
     else {
-        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, no distortion model set");
+        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, K matrix all zeros");
     }
 }
 

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -238,18 +238,23 @@ void FiducialsNode::camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg
         return;
     }
 
-    for (int i=0; i<3; i++) {
-        for (int j=0; j<3; j++) {
-            cameraMatrix.at<double>(i, j) = msg->K[i*3+j];
+    if (msg->distortion_model != "") {
+        for (int i=0; i<3; i++) {
+            for (int j=0; j<3; j++) {
+                cameraMatrix.at<double>(i, j) = msg->K[i*3+j];
+            }
         }
-    }
 
-    for (int i=0; i<5; i++) {
-        distortionCoeffs.at<double>(0,i) = msg->D[i];
-    }
+        for (int i=0; i<5; i++) {
+            distortionCoeffs.at<double>(0,i) = msg->D[i];
+        }
 
-    haveCamInfo = true;
-    frameId = msg->header.frame_id;
+        haveCamInfo = true;
+        frameId = msg->header.frame_id;
+    }
+    else {
+        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, no distortion model set");
+    }
 }
 
 void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr & msg) {

--- a/fiducial_detect/src/fiducial_detect.cpp
+++ b/fiducial_detect/src/fiducial_detect.cpp
@@ -174,12 +174,17 @@ void FiducialsNode::fiducial_cb(int id, int direction, double world_diagonal,
 
 void FiducialsNode::camInfoCallback(
     const sensor_msgs::CameraInfo::ConstPtr &msg) {
-    if (pose_est) {
-        pose_est->camInfoCallback(msg);
-    }
-    haveCamInfo = true;
+    if (msg->distortion_model != "") {
+        if (pose_est) {
+            pose_est->camInfoCallback(msg);
+        }
 
-    last_camera_frame = msg->header.frame_id;
+        haveCamInfo = true;
+        last_camera_frame = msg->header.frame_id;
+    }
+    else {
+        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, no distortion model set");
+    }
 }
 
 void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr &msg) {

--- a/fiducial_detect/src/fiducial_detect.cpp
+++ b/fiducial_detect/src/fiducial_detect.cpp
@@ -174,7 +174,7 @@ void FiducialsNode::fiducial_cb(int id, int direction, double world_diagonal,
 
 void FiducialsNode::camInfoCallback(
     const sensor_msgs::CameraInfo::ConstPtr &msg) {
-    if (msg->distortion_model != "") {
+    if (msg->K != boost::array<double, 9>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0})) {
         if (pose_est) {
             pose_est->camInfoCallback(msg);
         }
@@ -183,7 +183,7 @@ void FiducialsNode::camInfoCallback(
         last_camera_frame = msg->header.frame_id;
     }
     else {
-        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, no distortion model set");
+        ROS_WARN("%s", "CameraInfo message has invalid intrinsics, K matrix is all zeros");
     }
 }
 


### PR DESCRIPTION
Should prevent the situation in #90 from crashing with a segfault.