### PR TITLE
Keep publishing map -> odom tf even if not fiducials are visible

### DIFF
--- a/fiducial_slam/include/fiducial_slam/map.h
+++ b/fiducial_slam/include/fiducial_slam/map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Ubiquity Robotics
+ * Copyright (c) 2017-8, Ubiquity Robotics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -209,9 +209,15 @@ class Map {
     int initialFrameNum;
     int originFid;
 
+    bool havePose;
+    float tfPublishInterval;
+    ros::Time tfPublishTime;
+    geometry_msgs::TransformStamped poseTf;
+
     map<int, Fiducial> fiducials;
 
     Map(ros::NodeHandle &nh);
+    void update();
     void update(vector<Observation> &obs, const ros::Time &time);
     void autoInit(const vector<Observation> &obs, const ros::Time &time);
     int  updatePose(vector<Observation> &obs, const ros::Time &time,
@@ -224,6 +230,7 @@ class Map {
     bool saveMap();
     bool saveMap(std::string filename);
 
+    void publishTf();
     void publishMap();
     void publishMarker(Fiducial &fid);
     void publishMarkers();

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Ubiquity Robotics
+ * Copyright (c) 2017-8, Ubiquity Robotics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -185,7 +185,7 @@ int main(int argc, char ** argv) {
     while (ros::ok()) {
         ros::spinOnce(); 
         r.sleep();
-        node->fiducialMap.publishMarkers();
+        node->fiducialMap.update();
     }
 
     return 0;

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -172,6 +172,7 @@ Map::Map(ros::NodeHandle &nh) : tfBuffer(ros::Duration(30.0)){
     initialFrameNum = 0;
     originFid = -1;
     isInitializingMap = false;
+    havePose = false;
 
     listener = make_unique<tf2_ros::TransformListener>(tfBuffer);
 
@@ -189,6 +190,7 @@ Map::Map(ros::NodeHandle &nh) : tfBuffer(ros::Duration(30.0)){
     nh.param<std::string>("odom_frame", odomFrame, "odom");
     nh.param<std::string>("base_frame", baseFrame, "base_link");
 
+    nh.param<float>("tf_publish_interval", tfPublishInterval, 1.0);
     nh.param<double>("future_date_transforms", future_date_transforms, 0.1);
     nh.param<bool>("publish_6dof_pose", publish_6dof_pose, false);
 
@@ -467,15 +469,34 @@ int Map::updatePose(vector<Observation>& obs, const ros::Time &time,
         outPose.transform.getBasis().setRPY(0, 0, yaw);
     }
 
-    geometry_msgs::TransformStamped ts = toMsg(outPose);
-    ts.child_frame_id = outFrame;
-    ts.header.stamp += ros::Duration(future_date_transforms);
-    broadcaster.sendTransform(ts);
+    poseTf = toMsg(outPose);
+    poseTf.child_frame_id = outFrame;
+    havePose = true;
 
     ROS_INFO("Finished frame\n");
     return numEsts;
 }
 
+// Publish map -> odom tf
+
+void Map::publishTf()
+{
+    tfPublishTime = ros::Time::now();
+    poseTf.header.stamp = tfPublishTime + ros::Duration(future_date_transforms);
+    broadcaster.sendTransform(poseTf);
+}
+
+// publish latest tf if enough time has elapsed
+
+void Map::update()
+{
+    ros::Time now = ros::Time::now();
+    if (havePose && (now - tfPublishTime).toSec() > tfPublishInterval) {
+        publishTf();
+        tfPublishTime = now;
+    }
+    publishMarkers();
+}
 
 // Find closest fiducial to camera
 

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -472,6 +472,7 @@ int Map::updatePose(vector<Observation>& obs, const ros::Time &time,
     poseTf = toMsg(outPose);
     poseTf.child_frame_id = outFrame;
     havePose = true;
+    publishTf();
 
     ROS_INFO("Finished frame\n");
     return numEsts;

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -491,7 +491,8 @@ void Map::publishTf()
 void Map::update()
 {
     ros::Time now = ros::Time::now();
-    if (havePose && (now - tfPublishTime).toSec() > tfPublishInterval) {
+    if (havePose && tfPublishInterval != 0.0 &&
+        (now - tfPublishTime).toSec() > tfPublishInterval) {
         publishTf();
         tfPublishTime = now;
     }


### PR DESCRIPTION
Closes #102.

Tested by running with the `tf_publish_interval` set to 0 and 1, and unset, while observing the output of `rosrun tf tf_echo map odom` with fiducials visible and not visible.