### PR TITLE
Added in a systematic error parameter

### DIFF
--- a/fiducial_slam/launch/fiducial_slam.launch
+++ b/fiducial_slam/launch/fiducial_slam.launch
@@ -10,6 +10,7 @@
   <arg name="future_date_transforms" default="0.0"/>
   <arg name="publish_6dof_pose" default="false"/>
   <arg name="fiducial_len" default="0.14"/>
+  <arg name="systematic_error" default="0.01"/>
   <arg name="do_pose_estimation" default="false"/>
 
   <node type="fiducial_slam" pkg="fiducial_slam" output="screen" 

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -55,6 +55,7 @@ static double updateVarianceAlexey(double var1, double var2) {
 }
 
 static bool useAlexey = false;
+static float systematic_error = 0.001;
 
 // Update the variance of a gaussian that has been combined with another
 // Taking into account the degree of overlap
@@ -69,13 +70,13 @@ static double updateVarianceDavid(const tf2::Vector3 &newMean,
     double d1 = (mean1 - newMean).length2();
     double d2 = (mean2 - newMean).length2();
 
-    double newVar = sqrt(2.0*M_PI) * var1 * var2 *
+    double newVar = systematic_error + sqrt(2.0*M_PI) * var1 * var2 *
          exp(((d1 / (2.0*var1)) + d2 / (2.0*var2)));
 
     if (newVar > 100)
         newVar = 100;
-    if (newVar < 10e-4)
-        newVar = 10e-4;
+//    if (newVar < 10e-4)  //This line should be redundant if systematic_error does anything meaningful
+//        newVar = 10e-4;  //This line should be redundant if systematic_error does anything meaningful
     return newVar;
 }
 
@@ -191,6 +192,7 @@ Map::Map(ros::NodeHandle &nh) : tfBuffer(ros::Duration(30.0)){
     nh.param<std::string>("base_frame", baseFrame, "base_link");
 
     nh.param<float>("tf_publish_interval", tfPublishInterval, 1.0);
+    nh.param<float>("systematic_error", systematic_error, 0.01);
     nh.param<double>("future_date_transforms", future_date_transforms, 0.1);
     nh.param<bool>("publish_6dof_pose", publish_6dof_pose, false);
 

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -49,21 +49,21 @@
 
 // Update the variance of a gaussian that has been combined with another
 // Does not Take into account the degree of overlap of observations
-static double updateVarianceAlexey(double var1, double var2) {
+static double suminquadrature(double var1, double var2) {
 
     return max(1.0 / (1.0/var1 + 1.0/var2), 1e-6);
 }
 
-static bool useAlexey = false;
-static float systematic_error = 0.001;
+static bool sum_error_in_quadrature = false;
+static float systematic_error = 0.01;
 
 // Update the variance of a gaussian that has been combined with another
 // Taking into account the degree of overlap
 static double updateVarianceDavid(const tf2::Vector3 &newMean,
                                   const tf2::Vector3 &mean1, double var1,
                                   const tf2::Vector3 &mean2, double var2) {
-    if (useAlexey) {
-       return updateVarianceAlexey(var1, var2);
+    if (sum_error_in_quadrature) {
+       return suminquadrature(var1, var2);
     }
 
     //=((2*PI())^0.5)*C3*D3*EXP((((((C2-E2)^2))/(2*C3^2))+(((D2-E2)^2)/(2*(D3^2)))))
@@ -75,8 +75,8 @@ static double updateVarianceDavid(const tf2::Vector3 &newMean,
 
     if (newVar > 100)
         newVar = 100;
-//    if (newVar < 10e-4)  //This line should be redundant if systematic_error does anything meaningful
-//        newVar = 10e-4;  //This line should be redundant if systematic_error does anything meaningful
+    if (newVar < 10e-4)  //This line should be redundant if systematic_error does anything meaningful
+        newVar = 10e-4;  //This line should be redundant if systematic_error does anything meaningful
     return newVar;
 }
 
@@ -195,6 +195,8 @@ Map::Map(ros::NodeHandle &nh) : tfBuffer(ros::Duration(30.0)){
     nh.param<float>("systematic_error", systematic_error, 0.01);
     nh.param<double>("future_date_transforms", future_date_transforms, 0.1);
     nh.param<bool>("publish_6dof_pose", publish_6dof_pose, false);
+    nh.param<bool>("sum_error_in_quadrature", sum_error_in_quadrature, false);
+
 
     // threshold of object error for using multi-fidicial pose
     // set -ve to never use

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -124,7 +124,7 @@ TransformWithVariance averageTransforms(const TransformWithVariance& t1, const T
 
     out.transform.setOrigin((var1 * o2 + var2 * o1) / (var1 + var2));
     out.transform.setRotation(q1.slerp(q2, var1 / (var1 + var2)).normalized());
-    out.variance = updateVarianceAlexey(var1, var2);
+    out.variance = suminquadrature(var1, var2);
 
     return out;
 }


### PR DESCRIPTION
Added in a systematic error parameter. This parameter is intended to take in to account systematic (non-random) errors in the measurement of fiducial position. Non-random errors can be very pernicious, and can generate highly unexpected and difficult to resolve issues. For example if **all** the fiducials are slightly the wrong size this will not show up as a random variance. Similar systematic errors include, camera mis-calibration, sampling defects, digitization errors, lens flaring and so forth. Measurement accuracy in-homogeneity can also be considered a systematic error and this will also help with that issue although it probably should be treated explicitly rather than through this "hack". Ultimately the correct approach is to rigorously compute all these systematic errors and add them in to the model - we are simply saying that we think the systematic errors are less than the specified value.