### PR TITLE
Add params to ignore some fiducial Ids and override sizes

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -83,7 +83,7 @@ class FiducialsNode {
     cv::Mat distortionCoeffs;
     int frameNum;
     std::string frameId;
-    std::map<int, bool> ignoreIds;
+    std::vector<int> ignoreIds;
     std::map<int, double> fiducialLens;
 
 
@@ -360,7 +360,7 @@ void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr & msg) {
                          tvecs[i][0], tvecs[i][1], tvecs[i][2],
                          rvecs[i][0], rvecs[i][1], rvecs[i][2]);
 
-                if (ignoreIds.find(ids[i]) != ignoreIds.end()) {
+                if (std::count(ignoreIds.begin(), ignoreIds.end(), ids[i]) != 0) {
                     ROS_INFO("Ignoring id %d", ids[i]);
                     continue;
                 }
@@ -451,13 +451,13 @@ FiducialsNode::FiducialsNode(ros::NodeHandle & nh) : it(nh)
            int end = std::stoi(range[1]);
            ROS_INFO("Ignoring fiducial id range %d to %d", start, end);
            for (int j=start; j<=end; j++) {
-               ignoreIds[j]= true;
+               ignoreIds.push_back(j);
            }
         }
         else if (range.size() == 1) {
            int fid = std::stoi(range[0]);
            ROS_INFO("Ignoring fiducial id %d", fid);
-           ignoreIds[fid] =  true;
+           ignoreIds.push_back(fid);
         }
         else {
            ROS_ERROR("Malformed ignore_fiducials: %s", element.c_str());

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -441,6 +441,9 @@ FiducialsNode::FiducialsNode(ros::NodeHandle & nh) : it(nh)
     nh.param<string>("ignore_fiducials", str, "");
     boost::split(strs, str, boost::is_any_of(","));
     for (const string& element : strs) {
+        if (element == "") {
+           continue;
+        }
         std::vector<std::string> range;
         boost::split(range, element, boost::is_any_of("-"));
         if (range.size() == 2) {
@@ -451,8 +454,8 @@ FiducialsNode::FiducialsNode(ros::NodeHandle & nh) : it(nh)
                ignoreIds[j]= true;
            }
         }
-        else if (range.size() == 1){
-           int fid = std::stoi(element);
+        else if (range.size() == 1) {
+           int fid = std::stoi(range[0]);
            ROS_INFO("Ignoring fiducial id %d", fid);
            ignoreIds[fid] =  true;
         }
@@ -468,10 +471,13 @@ FiducialsNode::FiducialsNode(ros::NodeHandle & nh) : it(nh)
     nh.param<string>("fiducial_len_override", str, "");
     boost::split(strs, str, boost::is_any_of(","));
     for (const string& element : strs) {
+        if (element == "") {
+           continue;
+        }
         std::vector<std::string> parts;
         boost::split(parts, element, boost::is_any_of(":"));
         if (parts.size() == 2) {
-            double len = std::stof(parts[0]);
+            double len = std::stod(parts[0]);
             std::vector<std::string> range;
             boost::split(range, element, boost::is_any_of("-"));
             if (range.size() == 2) {


### PR DESCRIPTION
This PR adds two parameters to `aruco_detect`: `ignore_fiducials` and `fiducial_len_override`.

`ignore_fiducials` can take comma separated list of individual
    fiducial ids or ranges, eg "1,4,8,9-12,30-40"

`fiducial_len_override` can take comma separated list of size: id or size: range,
    e.g. "200.0: 12, 300.0: 200-300"
