### PR TITLE
Overhaul aruco marker generation (calculate svg values)

### DIFF
--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os, sys
+import em
 
 """
 Generate a PDF file containaing one or more fiducial marker for printing
@@ -15,36 +16,48 @@ def checkCmd(cmd, package):
      
 def genSvg(file, id, dicno):
     f = open(file, "w")
-    f.write("""<svg width="208.0mm" height="240.0mm"
+    f.write(em.expand("""<svg width="@(paper_width)mm" height="@(paper_height)mm"
  version="1.1"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns="http://www.w3.org/2000/svg">
 
-  <line x1="5.0mm" y1="5.0mm" x2="7.0mm" y2="5.0mm" style="stroke:black"/>
-  <line x1="195.0mm" y1="5.0mm" x2="197.0mm" y2="5.0mm" style="stroke:black"/>
-  <line x1="5.0mm" y1="21.0mm" x2="7.0mm" y2="21.0mm" style="stroke:black"/>
-  <line x1="5.0mm" y1="21.0mm" x2="5.0mm" y2="23.0mm" style="stroke:black"/>
-  <line x1="197.0mm" y1="21.0mm" x2="195.0mm" y2="21.0mm" style="stroke:black"/>
-  <line x1="197.0mm" y1="21.0mm" x2="197.0mm" y2="23.0mm" style="stroke:black"/>
+  <rect x="@((paper_width - fid_len)/2)mm" y="@((paper_height - fid_len)/2)mm" width="@(fid_len)mm" height="4.0mm" style="stroke:none; fill:black"/>
+  <rect x="@((paper_width - fid_len)/2)mm" y="@((paper_height + fid_len)/2 - 4)mm" width="@(fid_len)mm" height="4.0mm" style="stroke:none; fill:black"/>
+  <rect x="@((paper_width - fid_len)/2)mm" y="@((paper_height - fid_len)/2)mm" width="4.0mm" height="@(fid_len)mm" style="stroke:none; fill:black"/>
+  <rect x="@((paper_width + fid_len)/2 - 4)mm" y="@((paper_height - fid_len)/2)mm" width="4.0mm" height="@(fid_len)mm" style="stroke:none; fill:black"/>
+
+  <image x="@((paper_width - fid_len)/2)mm" y="@((paper_height - fid_len)/2)mm" width="@(fid_len)mm" height="@(fid_len)mm" xlink:href="marker@(id).png" />
+
+
+  @{cut = 15}
+
+  @{corner_x = (paper_width - fid_len)/2 - cut}
+  @{corner_y = (paper_height - fid_len)/2 - cut}
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x + 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y + 2)mm" style="stroke:black"/>
   
-  <image x="31.0mm" y="47.0mm" width="140.0mm" height="140.0mm" xlink:href="marker%d.png" />
+  <text x="@(paper_width/2)mm" y="@(corner_y - 2)mm" text-anchor="middle" style="font-family:ariel; font-size:12;">1 cm</text>
+  <line x1="@(paper_width/2 - 5)mm" y1="@(corner_y)mm" x2="@(paper_width/2 + 5)mm" y2="@(corner_y)mm" style="stroke:black"/>
 
-  <rect x="31.0mm" y="47.0mm" width="140.0mm" height="4.0mm" style="stroke:black; fill:black"/>
-  <rect x="31.0mm" y="183.0mm" width="140.0mm" height="4.0mm" style="stroke:black; fill:black"/>
-  <rect x="31.0mm" y="47.0mm" width="4.0mm" height="140.0mm" style="stroke:black; fill:black"/>
-  <rect x="167.0mm" y="47.0mm" width="4.0mm" height="140.0mm" style="stroke:black; fill:black"/>
+  @{corner_x = (paper_width + fid_len)/2 + cut}
+  @{corner_y = (paper_height - fid_len)/2 - cut}
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x - 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y + 2)mm" style="stroke:black"/>
 
-  <line x1="5.0mm" y1="213.0mm" x2="7.0mm" y2="213.0mm" style="stroke:black"/>
-  <line x1="5.0mm" y1="213.0mm" x2="5.0mm" y2="211.0mm" style="stroke:black"/>
-  <line x1="195.0mm" y1="213.0mm" x2="197.0mm" y2="213.0mm" style="stroke:black"/>
-  <line x1="197.0mm" y1="213.0mm" x2="197.0mm" y2="211.0mm" style="stroke:black"/>
-  <line x1="5.0mm" y1="229.0mm" x2="7.0mm" y2="229.0mm" style="stroke:black"/>
-  <line x1="195.0mm" y1="229.0mm" x2="197.0mm" y2="229.0mm" style="stroke:black"/>
+  @{corner_x = (paper_width - fid_len)/2 - cut}
+  @{corner_y = (paper_height + fid_len)/2 + cut}
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x + 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y - 2)mm" style="stroke:black"/>
 
-  <text x="90.0mm" y="220.0mm" style="font-family:ariel; font-size:24">%d D%d</text>
+  @{corner_x = (paper_width + fid_len)/2 + cut}
+  @{corner_y = (paper_height + fid_len)/2 + cut}
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x - 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
+  <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y - 2)mm" style="stroke:black"/>
+
+  <text x="@(paper_width/2)mm" y="220.0mm" text-anchor="middle" style="font-family:ariel; font-size:24;">@(id) D@(dicno)</text>
 
 </svg>
-""" % (id, id, dicno))
+""", {"id": id, "dicno": dicno, "paper_width": 215.9, "paper_height": 279.4, "fid_len": 140.0}))
     f.close()
 
 if __name__ == "__main__":
@@ -67,9 +80,9 @@ if __name__ == "__main__":
         sys.stdout.flush()
         os.system("rosrun aruco_detect create_marker --id=%d --ms=2000 --d=%d marker%d.png" % (i, dicno, i))
         genSvg("marker%d.svg" % i, i, 7)
-        os.system("inkscape --without-gui --export-pdf=marker%d.pdf marker%d.svg" % (i, i))
-        os.remove("marker%d.svg" % i)
-        os.remove("marker%d.png" % i)
+        os.system("inkscape --without-gui --export-area-page --export-pdf=marker%d.pdf marker%d.svg" % (i, i))
+#        os.remove("marker%d.svg" % i)
+#        os.remove("marker%d.png" % i)
     print "Combining into %s" % outfile
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))
     for f in pdfs:

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -94,7 +94,6 @@ if __name__ == "__main__":
     for f in pdfs:
         os.remove(f)
 
-    print '\033[91m' + "After printing, please make sure that the long lines \
-around the marker are EXACTLY 14.0 cm long"
-    print "This is required for accurate position estimation." + '\033[0m'
-  
+    print '\033[91m' + """After printing, please make sure thatthe long lines around the marker are
+EXACTLY 14.0 cm long. This is required for accurate position estimation.""" + '\033[0m'
+

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -54,7 +54,7 @@ def genSvg(file, id, dicno):
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x - 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y - 2)mm" style="stroke:black"/>
 
-  <text x="@(paper_width/2)mm" y="220.0mm" text-anchor="middle" style="font-family:ariel; font-size:24;">@(id) D@(dicno)</text>
+  <text x="@(paper_width/2)mm" y="@((paper_height + fid_len)/2 + 30)mm" text-anchor="middle" style="font-family:ariel; font-size:24;">@(id) D@(dicno)</text>
 
 </svg>
 """, {"id": id, "dicno": dicno, "paper_width": 215.9, "paper_height": 279.4, "fid_len": 140.0}))

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -29,25 +29,31 @@ def genSvg(file, id, dicno):
   <image x="@((paper_width - fid_len)/2)mm" y="@((paper_height - fid_len)/2)mm" width="@(fid_len)mm" height="@(fid_len)mm" xlink:href="marker@(id).png" />
 
 
-  @{cut = 15}
+  @{cut = max(fid_len/10 * 1.4, 10)}
 
   @{corner_x = (paper_width - fid_len)/2 - cut}
   @{corner_y = (paper_height - fid_len)/2 - cut}
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x + 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y + 2)mm" style="stroke:black"/>
   
-  <text x="@(paper_width/2)mm" y="@(corner_y - 2)mm" text-anchor="middle" style="font-family:ariel; font-size:12;">1 cm</text>
-  <line x1="@(paper_width/2 - 5)mm" y1="@(corner_y)mm" x2="@(paper_width/2 + 5)mm" y2="@(corner_y)mm" style="stroke:black"/>
-
   @{corner_x = (paper_width + fid_len)/2 + cut}
   @{corner_y = (paper_height - fid_len)/2 - cut}
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x - 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y + 2)mm" style="stroke:black"/>
 
+  <text x="@(paper_width/2)mm" y="@(corner_y - 1)mm" text-anchor="middle" style="font-family:ariel; font-size:8;">
+      This line should be exactly @(fid_len/10)cm long. 
+  </text>
+  <line x1="@(paper_width/2 - fid_len/2)mm" y1="@(corner_y)mm" x2="@(paper_width/2 + fid_len/2)mm" y2="@(corner_y)mm" style="stroke:black"/>
+  <line x1="@(corner_x)mm" y1="@(paper_height/2 - fid_len/2)mm" x2="@(corner_x)mm" y2="@(paper_height/2 + fid_len/2)mm" style="stroke:black"/>
+
   @{corner_x = (paper_width - fid_len)/2 - cut}
   @{corner_y = (paper_height + fid_len)/2 + cut}
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x + 2)mm" y2="@(corner_y)mm" style="stroke:black"/>
   <line x1="@(corner_x)mm" y1="@(corner_y)mm" x2="@(corner_x)mm" y2="@(corner_y - 2)mm" style="stroke:black"/>
+
+  <line x1="@(corner_x)mm" y1="@(paper_height/2 - fid_len/2)mm" x2="@(corner_x)mm" y2="@(paper_height/2 + fid_len/2)mm" style="stroke:black"/>
+  <line x1="@(paper_width/2 - fid_len/2)mm" y1="@(corner_y)mm" x2="@(paper_width/2 + fid_len/2)mm" y2="@(corner_y)mm" style="stroke:black"/>
 
   @{corner_x = (paper_width + fid_len)/2 + cut}
   @{corner_y = (paper_height + fid_len)/2 + cut}
@@ -87,3 +93,8 @@ if __name__ == "__main__":
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))
     for f in pdfs:
         os.remove(f)
+
+    print '\033[91m' + "After printing, please make sure that the long lines \
+around the marker are EXACTLY 14.0 cm long"
+    print "This is required for accurate position estimation." + '\033[0m'
+  

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -81,8 +81,8 @@ if __name__ == "__main__":
         os.system("rosrun aruco_detect create_marker --id=%d --ms=2000 --d=%d marker%d.png" % (i, dicno, i))
         genSvg("marker%d.svg" % i, i, 7)
         os.system("inkscape --without-gui --export-area-page --export-pdf=marker%d.pdf marker%d.svg" % (i, i))
-#        os.remove("marker%d.svg" % i)
-#        os.remove("marker%d.png" % i)
+        os.remove("marker%d.svg" % i)
+        os.remove("marker%d.png" % i)
     print "Combining into %s" % outfile
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))
     for f in pdfs:


### PR DESCRIPTION
This makes create_markers generate an svg at a paper size directly. It also adds a 1cm mark for measurement.

@davecrawley can you provide feedback on the new generated pdf
@jim-v Please review the change

Fixes #115 

![image](https://user-images.githubusercontent.com/2825327/46578030-198b0f80-c9a9-11e8-8904-2b752fbf1218.png)

