### PR TITLE
Improve accuracy of map

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -94,7 +94,7 @@ class FiducialsNode {
 
     void estimatePoseSingleMarkers(const vector<int> &ids,
                                    const vector<vector<Point2f > >&corners,
-                                   float markerLength,
+                                   double markerLength,
                                    const cv::Mat &cameraMatrix,
                                    const cv::Mat &distCoeffs,
                                    vector<Vec3d>& rvecs, vector<Vec3d>& tvecs,
@@ -116,16 +116,16 @@ class FiducialsNode {
 /**
   * @brief Return object points for the system centered in a single marker, given the marker length
   */
-static void getSingleMarkerObjectPoints(float markerLength, vector<Point3f>& objPoints) {
+static void getSingleMarkerObjectPoints(double markerLength, vector<Point3d>& objPoints) {
 
     CV_Assert(markerLength > 0);
 
     // set coordinate system in the middle of the marker, with Z pointing out
     objPoints.clear();
-    objPoints.push_back(Vec3f(-markerLength / 2.f, markerLength / 2.f, 0));
-    objPoints.push_back(Vec3f( markerLength / 2.f, markerLength / 2.f, 0));
-    objPoints.push_back(Vec3f( markerLength / 2.f,-markerLength / 2.f, 0));
-    objPoints.push_back(Vec3f(-markerLength / 2.f,-markerLength / 2.f, 0));
+    objPoints.push_back(Vec3d(-markerLength / 2., markerLength / 2.f, 0.));
+    objPoints.push_back(Vec3d( markerLength / 2., markerLength / 2.f, 0.));
+    objPoints.push_back(Vec3d( markerLength / 2.,-markerLength / 2.f, 0.));
+    objPoints.push_back(Vec3d(-markerLength / 2.,-markerLength / 2.f, 0.));
 }
 
 // Euclidean distance between two points
@@ -168,7 +168,7 @@ static double calcFiducialArea(const std::vector<cv::Point2f> &pts)
 }
 
 // estimate reprojection error
-static double getReprojectionError(const vector<Point3f> &objectPoints,
+static double getReprojectionError(const vector<Point3d> &objectPoints,
                             const vector<Point2f> &imagePoints,
                             const Mat &cameraMatrix, const Mat  &distCoeffs,
                             const Vec3d &rvec, const Vec3d &tvec) {
@@ -184,13 +184,13 @@ static double getReprojectionError(const vector<Point3f> &objectPoints,
         double error = dist(imagePoints[i], projectedPoints[i]);
         totalError += error*error;
     }
-    double rerror = totalError/objectPoints.size();
+    double rerror = totalError/(double)objectPoints.size();
     return rerror;
 }
 
 void FiducialsNode::estimatePoseSingleMarkers(const vector<int> &ids,
                                 const vector<vector<Point2f > >&corners,
-                                float markerLength,
+                                double markerLength,
                                 const cv::Mat &cameraMatrix,
                                 const cv::Mat &distCoeffs,
                                 vector<Vec3d>& rvecs, vector<Vec3d>& tvecs,
@@ -198,7 +198,7 @@ void FiducialsNode::estimatePoseSingleMarkers(const vector<int> &ids,
 
     CV_Assert(markerLength > 0);
 
-    vector<Point3f> markerObjPoints;
+    vector<Point3d> markerObjPoints;
     int nMarkers = (int)corners.size();
     rvecs.reserve(nMarkers);
     tvecs.reserve(nMarkers);
@@ -318,7 +318,7 @@ void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr & msg) {
         aruco::detectMarkers(cv_ptr->image, dictionary, corners, ids, detectorParams);
         ROS_INFO("Detected %d markers", (int)ids.size());
 
-        for (int i=0; i<ids.size(); i++) {
+        for (unsigned int i=0; i<ids.size(); i++) {
             fiducial_msgs::Fiducial fid;
             fid.fiducial_id = ids[i];
 
@@ -353,7 +353,7 @@ void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr & msg) {
                                       rvecs, tvecs,
                                       reprojectionError);
 
-            for (int i=0; i<ids.size(); i++) {
+            for (unsigned int i=0; i<ids.size(); i++) {
                 aruco::drawAxis(cv_ptr->image, cameraMatrix, distortionCoeffs,
                                 rvecs[i], tvecs[i], fiducial_len);
 
@@ -401,6 +401,10 @@ void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr & msg) {
 
         if (publish_images) {
 	    image_pub.publish(cv_ptr->toImageMsg());
+            static int frame = 0;
+            char file[100];
+            sprintf(file, "frame%04d.png", frame++);
+            cv::imwrite(file, cv_ptr->image);
         }
     }
     catch(cv_bridge::Exception & e) {

--- a/fiducial_slam/include/fiducial_slam/estimator.h
+++ b/fiducial_slam/include/fiducial_slam/estimator.h
@@ -70,13 +70,13 @@ class Estimator {
     std::map<int, cv::Vec3d> rvecHistory;
     std::map<int, cv::Vec3d> tvecHistory;
 
-    void estimatePose(int fid, const vector<Point3f> &worldPoints,
-                      const vector<Point2f> &imagePoints,
+    void estimatePose(int fid, const vector<Point3d> &worldPoints,
+                      const vector<Point2d> &imagePoints,
                       Observation &obs, fiducial_msgs::FiducialTransform &ft,
                       const ros::Time& stamp, const string& frame);
 
-    double getReprojectionError(const vector<Point3f> &objectPoints,
-                                const vector<Point2f> &imagePoints,
+    double getReprojectionError(const vector<Point3d> &objectPoints,
+                                const vector<Point2d> &imagePoints,
                                 const Vec3d &rvec, const Vec3d &tvec);
 
   public:

--- a/fiducial_slam/include/fiducial_slam/map.h
+++ b/fiducial_slam/include/fiducial_slam/map.h
@@ -92,9 +92,10 @@ class TransformWithVariance {
     }
 
     // Used to combine this transform with another one keeping variance the same
-    void operator*=(const tf2::Transform& rhs) {
+    TransformWithVariance& operator*=(const tf2::Transform& rhs) {
         transform *= rhs;
         // No need to change the variance, we are assuming that rhs has variance of 0
+        return *this;
     }
     friend TransformWithVariance operator*(TransformWithVariance lhs, const tf2::Transform& rhs) {
         lhs *= rhs;

--- a/fiducial_slam/include/fiducial_slam/map.h
+++ b/fiducial_slam/include/fiducial_slam/map.h
@@ -92,7 +92,7 @@ class TransformWithVariance {
     }
 
     // Used to combine this transform with another one keeping variance the same
-    TransformWithVariance& operator*=(const tf2::Transform& rhs) {
+    void operator*=(const tf2::Transform& rhs) {
         transform *= rhs;
         // No need to change the variance, we are assuming that rhs has variance of 0
     }
@@ -149,18 +149,15 @@ inline geometry_msgs::TransformStamped toMsg(const tf2::Stamped<TransformWithVar
 class Observation {
   public:
     int fid;
-    double imageError;
     tf2::Stamped<TransformWithVariance> T_fidCam;
     tf2::Stamped<TransformWithVariance> T_camFid;
 
     // how well this fitted the consensus of cameraPose
     tf2::Vector3 position;
-    double poseError;
 
     Observation() {};
 
-    Observation(int fid, const tf2::Stamped<TransformWithVariance>& camFid,
-                double ierr, double oerr);
+    Observation(int fid, const tf2::Stamped<TransformWithVariance>& camFid);
 };
 
 // A single fiducial that is in the map

--- a/fiducial_slam/src/estimator.cpp
+++ b/fiducial_slam/src/estimator.cpp
@@ -98,7 +98,7 @@ double Estimator::getReprojectionError(const vector<Point3d> &objectPoints,
 
     // calculate RMS image error
     double totalError = 0.0;
-    for (unsigned int i=0; i<objectPoints.size(); i++) {
+    for (size_t i=0; i<objectPoints.size(); i++) {
         double error = dist(imagePoints[i], projectedPoints[i]);
         totalError += error*error;
     }
@@ -193,7 +193,7 @@ void Estimator::camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg)
         }
     }
 
-    for (unsigned int i=0; i<msg->D.size(); i++) {
+    for (size_t i=0; i<msg->D.size(); i++) {
         distortionCoeffs.at<double>(0,i) = msg->D[i];
     }
 
@@ -219,7 +219,7 @@ void Estimator::estimatePoses(const fiducial_msgs::FiducialArray::ConstPtr& msg,
     vector<Point3d> allWorldPoints;
     vector<Point2d> allImagePoints;
 
-    for (unsigned int i=0; i<msg->fiducials.size(); i++) {
+    for (size_t i=0; i<msg->fiducials.size(); i++) {
 
         const fiducial_msgs::Fiducial& fid = msg->fiducials[i];
 

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -93,7 +93,7 @@ void FiducialSlam::transformCallback(const fiducial_msgs::FiducialTransformArray
 
     vector<Observation> observations;
 
-    for (unsigned int i=0; i<msg->transforms.size(); i++) {
+    for (size_t i=0; i<msg->transforms.size(); i++) {
         const fiducial_msgs::FiducialTransform &ft = msg->transforms[i];
 
         tf2::Vector3 tvec(ft.transform.translation.x,

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -269,7 +269,7 @@ void Map::updateMap(const vector<Observation>& obs, const ros::Time &time,
         f.visible = false;
     }
 
-    for (unsigned int i=0; i<obs.size(); i++) {
+    for (size_t i=0; i<obs.size(); i++) {
         const Observation &o = obs[i];
         if (o.fid == 0) {
             continue;
@@ -306,7 +306,7 @@ void Map::updateMap(const vector<Observation>& obs, const ros::Time &time,
            f.numObs++;
         }
 
-        for (unsigned int j=0; j<obs.size(); j++) {
+        for (size_t j=0; j<obs.size(); j++) {
             int fid = obs[j].fid;
             if (f.id != fid) {
                 f.links[fid] = 1;
@@ -345,7 +345,7 @@ int Map::updatePose(vector<Observation>& obs, const ros::Time &time,
     tf2::Stamped<TransformWithVariance> T_fid0Cam;
     bool useMulti = false;
 
-    for (unsigned int i=0; i<obs.size(); i++) {
+    for (size_t i=0; i<obs.size(); i++) {
         Observation &o = obs[i];
 
         if (o.fid == 0) {
@@ -526,7 +526,7 @@ static int findClosestObs(const vector<Observation>& obs)
     double smallestDist = -1;
     int closestIdx = -1;
 
-    for (unsigned int i=0; i<obs.size(); i++) {
+    for (size_t i=0; i<obs.size(); i++) {
         const Observation &o = obs[0];
         double d = o.T_camFid.transform.getOrigin().length2();
         if (smallestDist < 0 || d < smallestDist) {
@@ -571,7 +571,7 @@ void Map::autoInit(const vector<Observation>& obs, const ros::Time &time) {
         fiducials[o.fid] = Fiducial(o.fid, T);
     }
     else {
-        for (unsigned int i=0; i<obs.size(); i++) {
+        for (size_t i=0; i<obs.size(); i++) {
             const Observation &o = obs[0];
 
             if (o.fid == originFid) {


### PR DESCRIPTION
- Add parameter to use fiducial area as weighting instead of reprojection error (default)
- Add parameter for for scaling weights (default 1e9)
- Remove compiler warnings

With the test data we have been using: 
 
Reprojection, scale 1: residual: 0.116711
Area, scale 1: residual: 0.116711
Reprojection, scale 1e9: residual 0.072482
Area, scale 1e9: residual 0.093470

Fixes #133 

