### PR TITLE
call genMarker with correct arguments with no joblib

### DIFF
--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     except ImportError:
         # Fallback to serial version
         for i in markers:
-            genMarker(i, dicno)
+            genMarker(i, dicno, paper_size)
 
     print "Combining into %s" % outfile
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))


### PR DESCRIPTION
Fixes #146 