### PR TITLE
Populate fiducial transform array stamp data

### DIFF
--- a/fiducial_slam/src/estimator.cpp
+++ b/fiducial_slam/src/estimator.cpp
@@ -265,4 +265,6 @@ void Estimator::estimatePoses(const fiducial_msgs::FiducialArray::ConstPtr& msg,
         observations.push_back(obs);
         outMsg.transforms.push_back(ft);
     }
+
+    outMsg.header.stamp = msg->header.stamp;
 }


### PR DESCRIPTION
It is currently left empty and is useful in determining if an fiducial detection is too old to use.