### PR TITLE
Compatibility with Melodic, remove opencv3 dependency

### DIFF
--- a/aruco_detect/package.xml
+++ b/aruco_detect/package.xml
@@ -21,7 +21,6 @@
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>opencv3</depend>
   <depend>fiducial_msgs</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>python-cairosvg</depend>

--- a/fiducial_slam/package.xml
+++ b/fiducial_slam/package.xml
@@ -21,7 +21,6 @@
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>opencv3</depend>
   <depend>fiducial_msgs</depend>
   <depend>dynamic_reconfigure</depend>
 


### PR DESCRIPTION
opencv3 is no longer a package in melodic, so we use cv_bridge
to get the correct opencv transitively

http://wiki.ros.org/opencv3#package.xml

This allows #155 to be resolved. 