### PR TITLE
Fix fiducial_len_override

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -530,7 +530,7 @@ FiducialsNode::FiducialsNode() : nh(ros::NodeHandle("~")), it(nh)
         std::vector<std::string> parts;
         boost::split(parts, element, boost::is_any_of(":"));
         if (parts.size() == 2) {
-            double len = std::stod(parts[0]);
+            double len = std::stod(parts[1]);
             std::vector<std::string> range;
             boost::split(range, element, boost::is_any_of("-"));
             if (range.size() == 2) {

--- a/fiducial_slam/CMakeLists.txt
+++ b/fiducial_slam/CMakeLists.txt
@@ -16,8 +16,21 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED)
 
-catkin_package(INCLUDE_DIRS include
-  DEPENDS OpenCV)
+##############
+## Services ##
+##############
+
+## Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  AddFiducial.srv
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ###########
 ## Build ##
@@ -26,6 +39,9 @@ catkin_package(INCLUDE_DIRS include
 add_definitions(-std=c++11)
 
 include_directories(${catkin_INCLUDE_DIRS} include)
+catkin_package(INCLUDE_DIRS include
+  DEPENDS OpenCV)
+
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 add_executable(fiducial_slam src/fiducial_slam.cpp src/estimator.cpp src/map.cpp src/transform_with_variance.cpp)

--- a/fiducial_slam/include/fiducial_slam/map.h
+++ b/fiducial_slam/include/fiducial_slam/map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-8, Ubiquity Robotics
+ * Copyright (c) 2017-9, Ubiquity Robotics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,6 +54,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <std_srvs/Empty.h>
+#include <fiducial_slam/AddFiducial.h>
 
 #include <fiducial_slam/transform_with_variance.h>
 
@@ -100,7 +101,11 @@ public:
     ros::Publisher cameraPosePub;
 
     ros::ServiceServer clearSrv;
+    ros::ServiceServer addSrv;
     bool clearCallback(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
+    bool addFiducialCallback(fiducial_slam::AddFiducial::Request &req,
+                             fiducial_slam::AddFiducial::Response &res);
+
     std::string mapFilename;
     std::string mapFrame;
     std::string odomFrame;
@@ -126,6 +131,7 @@ public:
     geometry_msgs::TransformStamped poseTf;
 
     std::map<int, Fiducial> fiducials;
+    int fiducialToAdd;
 
     Map(ros::NodeHandle &nh);
     void update();
@@ -135,6 +141,7 @@ public:
                    tf2::Stamped<TransformWithVariance> &cameraPose);
     void updateMap(const std::vector<Observation> &obs, const ros::Time &time,
                    const tf2::Stamped<TransformWithVariance> &cameraPose);
+    void handleAddFiducial(const std::vector<Observation> &obs);
 
     bool loadMap();
     bool loadMap(std::string filename);

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -524,6 +524,7 @@ void Map::handleAddFiducial(const std::vector<Observation> &obs) {
         if (o.fid == fiducialToAdd) {
             ROS_INFO("Adding fiducial_id %d to map", fiducialToAdd);
 
+
             tf2::Stamped<TransformWithVariance> T = o.T_camFid;
 
             // Take into account position of camera on base
@@ -536,11 +537,15 @@ void Map::handleAddFiducial(const std::vector<Observation> &obs) {
             // Take into account position of robot in the world if known
             tf2::Transform T_mapBase;
             if (lookupTransform(mapFrame, baseFrame, ros::Time(0), T_mapBase)) {
-                printf("We know where we are");
                 T.setData(T_mapBase * T);
+            }
+            else {
+                ROS_INFO("Placing robot at the origin");
             }
 
             fiducials[o.fid] = Fiducial(o.fid, T);
+            fiducials[originFid].pose.variance = 0.0;
+            isInitializingMap = false;
 
             fiducialToAdd = -1;
             return;

--- a/fiducial_slam/srv/AddFiducial.srv
+++ b/fiducial_slam/srv/AddFiducial.srv
@@ -1,0 +1,2 @@
+int32 fiducial_id
+---


### PR DESCRIPTION
Fixes #178 

Before

```[ INFO] [1560238888.881680030]: Setting fiducial id range 0 - 3 length to 0.000000
[ INFO] [1560238888.882160282]: Setting fiducial id 4 length to 4.000000
```

After

```[ INFO] [1560239072.212939144]: Setting fiducial id range 0 - 3 length to 0.100000
[ INFO] [1560239072.213394999]: Setting fiducial id 4 length to 0.150000
```