### PR TITLE
Fix fiducial_len_override bug

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -530,7 +530,7 @@ FiducialsNode::FiducialsNode() : nh(ros::NodeHandle("~")), it(nh)
         std::vector<std::string> parts;
         boost::split(parts, element, boost::is_any_of(":"));
         if (parts.size() == 2) {
-            double len = std::stod(parts[0]);
+            double len = std::stod(parts[1]);
             std::vector<std::string> range;
             boost::split(range, element, boost::is_any_of("-"));
             if (range.size() == 2) {


### PR DESCRIPTION
Fixes #178

Tested with:
```
        <param name="fiducial_len_override" value="0-3: 0.1, 4: 0.15"/>
```

Before:

```[ INFO] [1560238888.881680030]: Setting fiducial id range 0 - 3 length to 0.000000
[ INFO] [1560238888.882160282]: Setting fiducial id 4 length to 4.000000
```

After:

```[ INFO] [1560239394.526257919]: Setting fiducial id range 0 - 3 length to 0.100000
[ INFO] [1560239394.526717422]: Setting fiducial id 4 length to 0.150000
```