### PR TITLE
Use FrameId in rviz markers

### DIFF
--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -149,14 +149,11 @@ int main(int argc, char **argv) {
     node = make_unique<FiducialSlam>(nh);
     signal(SIGINT, mySigintHandler);
 
-    ROS_INFO("Chur's version");
-
     ros::Rate r(20);
     while (ros::ok()) {
         ros::spinOnce();
-        usleep(50);
+        r.sleep();
         node->fiducialMap.update();
-
     }
 
     return 0;

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -149,11 +149,14 @@ int main(int argc, char **argv) {
     node = make_unique<FiducialSlam>(nh);
     signal(SIGINT, mySigintHandler);
 
+    ROS_INFO("Chur's version");
+
     ros::Rate r(20);
     while (ros::ok()) {
         ros::spinOnce();
-        r.sleep();
+        usleep(50);
         node->fiducialMap.update();
+
     }
 
     return 0;

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -692,14 +692,14 @@ void Map::publishMarker(Fiducial &fid) {
     }
     marker.id = fid.id;
     marker.ns = "fiducial";
-    marker.header.frame_id = "/map";
+    marker.header.frame_id = mapFrame;
     markerPub.publish(marker);
 
     // cylinder scaled by stddev
     visualization_msgs::Marker cylinder;
     cylinder.type = visualization_msgs::Marker::CYLINDER;
     cylinder.action = visualization_msgs::Marker::ADD;
-    cylinder.header.frame_id = "/map";
+    cylinder.header.frame_id = mapFrame;
     cylinder.color.r = 0.0f;
     cylinder.color.g = 0.0f;
     cylinder.color.b = 1.0f;
@@ -718,7 +718,7 @@ void Map::publishMarker(Fiducial &fid) {
     visualization_msgs::Marker text;
     text.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
     text.action = visualization_msgs::Marker::ADD;
-    text.header.frame_id = "/map";
+    text.header.frame_id = mapFrame;
     text.color.r = text.color.g = text.color.b = text.color.a = 1.0f;
     text.id = fid.id;
     text.scale.x = text.scale.y = text.scale.z = 0.1;
@@ -735,7 +735,7 @@ void Map::publishMarker(Fiducial &fid) {
     visualization_msgs::Marker links;
     links.type = visualization_msgs::Marker::LINE_LIST;
     links.action = visualization_msgs::Marker::ADD;
-    links.header.frame_id = "/map";
+    links.header.frame_id = mapFrame;
     links.color.r = 0.0f;
     links.color.g = 0.0f;
     links.color.b = 1.0f;
@@ -778,7 +778,7 @@ void Map::drawLine(const tf2::Vector3 &p0, const tf2::Vector3 &p1) {
     visualization_msgs::Marker line;
     line.type = visualization_msgs::Marker::LINE_LIST;
     line.action = visualization_msgs::Marker::ADD;
-    line.header.frame_id = "/map";
+    line.header.frame_id = mapFrame;
     line.color.r = 1.0f;
     line.color.g = 0.0f;
     line.color.b = 0.0f;


### PR DESCRIPTION
Just a quick fix to make the rviz markers display well no matter the frame id used for the map.