### PR TITLE
increase range for PerimeterRate params

### DIFF
--- a/aruco_detect/cfg/DetectorParams.cfg
+++ b/aruco_detect/cfg/DetectorParams.cfg
@@ -66,12 +66,12 @@ gen.add("minMarkerDistanceRate",                  double_t, 0,
         0.1, 0, 1)
 
 gen.add("minMarkerPerimeterRate",                 double_t, 0,
-        "Determine minumum perimeter for marker contour to be detected. This is defined as a rate respect to the maximum dimension of the input image",
-        0.03, 0, 1)
+        "Determine minimum perimeter for marker contour to be detected. This is defined as a rate respect to the maximum dimension of the input image",
+        0.03, 0, 4)
 
 gen.add("maxMarkerPerimeterRate",                 double_t, 0,
         "Determine maximum perimeter for marker contour to be detected. This is defined as a rate respect to the maximum dimension of the input image",
-        4.0, 0, 1)
+        4.0, 0, 4)
 
 gen.add("minOtsuStdDev",                          double_t, 0,
         "Minimun standard deviation in pixels values during the decodification step to apply Otsu thresholding (otherwise, all the bits are set to 0 or 1 depending on mean higher than 128 or not)",


### PR DESCRIPTION
This PR extends the maximum rate for perimeter params to 4 since the perimeter contains 4 edges and is compared to the longest edge of the image.

Before this change the parameter `maxMarkerPerimeterRate` was clipped to 1.0 instead of the default value 4.0. This lead to false detection of big markers where the detected marker is much smaller than the real one. With this change big markers can be detected correctly.