### PR TITLE
Updated maxMarkerPerimeterRate max value

### DIFF
--- a/aruco_detect/cfg/DetectorParams.cfg
+++ b/aruco_detect/cfg/DetectorParams.cfg
@@ -71,7 +71,7 @@ gen.add("minMarkerPerimeterRate",                 double_t, 0,
 
 gen.add("maxMarkerPerimeterRate",                 double_t, 0,
         "Determine maximum perimeter for marker contour to be detected. This is defined as a rate respect to the maximum dimension of the input image",
-        4.0, 0, 1)
+        4.0, 0, 4.0)
 
 gen.add("minOtsuStdDev",                          double_t, 0,
         "Minimun standard deviation in pixels values during the decodification step to apply Otsu thresholding (otherwise, all the bits are set to 0 or 1 depending on mean higher than 128 or not)",


### PR DESCRIPTION
There were problems detecting aruco markers up close, and I realised that the maxMarkerPerimeterRate parameter's maximum value has been set to 1.0, which was below the default value of 4.0. I have since changed this value and it should be able to detect aruco markers up close to the camera.