### PR TITLE
fixed aruco detect remaps to relative topic names to suport namespaces

### DIFF
--- a/aruco_detect/launch/aruco_detect.launch
+++ b/aruco_detect/launch/aruco_detect.launch
@@ -19,8 +19,8 @@
     <param name="do_pose_estimation" value="$(arg do_pose_estimation)"/>
     <param name="ignore_fiducials" value="$(arg ignore_fiducials)"/>
     <param name="fiducial_len_override" value="$(arg fiducial_len_override)"/>
-    <remap from="/camera/compressed" 
+    <remap from="camera/compressed" 
         to="$(arg camera)/$(arg image)/$(arg transport)"/>
-    <remap from="/camera_info" to="$(arg camera)/camera_info"/>
+    <remap from="camera_info" to="$(arg camera)/camera_info"/>
   </node>
 </launch>


### PR DESCRIPTION
On a robot that has exported a ROS_NAMESPACE, aruco detect does not map topics correctly, because the remap takes in absolute topics and that can not be modified from terminal like other topics can be (eg. camera topic):

`mon launch aruco_detect aruco_detect.launch camera:=raspicam_node`

The changes that are made also work with the rest of the system when ROS_NAMESPACE is not set.

test that it works within magni gazebo with

`roslaunch magni_gazebo fiducial_world.launch`
