### PR TITLE
Create marker script updated for Python 3 with additional changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 *.pyc
+.vscode
+**log

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -34,7 +34,7 @@ def checkCmd(cmd, package):
     sudo apt install %s""" % (cmd, package))
         sys.exit(1)
      
-def genSvg(id, dicno, paper_size):
+def genSvg(id, dicno, paper_size, fid_len):
     return em.expand("""<svg width="@(paper_width)mm" height="@(paper_height)mm"
  version="1.1"
  xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -82,15 +82,15 @@ def genSvg(id, dicno, paper_size):
   <text x="@(paper_width/2)mm" y="@((paper_height + fid_len)/2 + 30)mm" text-anchor="middle" style="font-family:ariel; font-size:24;">@(id) D@(dicno)</text>
 
 </svg>
-""", {"id": id, "dicno": dicno, "paper_width": paper_size[0], "paper_height": paper_size[1], "fid_len": 140.0})
+""", {"id": id, "dicno": dicno, "paper_width": paper_size[0], "paper_height": paper_size[1], "fid_len": (fid_len*10.0)})
 
-def genMarker(i, dicno, paper_size):
+def genMarker(i, dicno, paper_size, fid_len):
     print(" Marker %d\r" % i)
     sys.stdout.flush()
     aruco_dict = aruco.Dictionary_get(dicno)
-    img = aruco.drawMarker(aruco_dict, i, 2000)
+    img = aruco.drawMarker(aruco_dict, i, int(2000 * (fid_len/14.0)))
     cv2.imwrite("/tmp/marker%d.png" % i, img)
-    svg = genSvg(i, dicno, paper_size)
+    svg = genSvg(i, dicno, paper_size, fid_len)
     cairosvg.svg2pdf(bytestring=svg, write_to='/tmp/marker%d.pdf' % i)
     # Old slower method using subprocess for SVG to PDF conversion
     # cairo = subprocess.Popen(('cairosvg', '-f', 'pdf', '-o', '/tmp/marker%d.pdf' % i, '/dev/stdin'), stdin=subprocess.PIPE)
@@ -113,6 +113,8 @@ if __name__ == "__main__":
                         help='dictionary to generate from')
     parser.add_argument('--paper-size', dest='paper_size', action='store',
                         default='letter', help='paper size to use (letter or a4)')
+    parser.add_argument('--fid-len', type=float, dest='fid_len', action="store",
+                        default="14.0", help="fiducial side length in centimeter")
 
     args = parser.parse_args()
 
@@ -127,20 +129,22 @@ if __name__ == "__main__":
     elif args.paper_size == 'a4':
         paper_size  = (210, 297)
 
+    fid_len = args.fid_len
+
     try:
         # For a parallel version
         from joblib import Parallel, delayed
-        Parallel(n_jobs=-1)(delayed(genMarker)(i, dicno, paper_size) for i in markers)
+        Parallel(n_jobs=-1)(delayed(genMarker)(i, dicno, paper_size, fid_len) for i in markers)
     except ImportError:
         # Fallback to serial version
         for i in markers:
-            genMarker(i, dicno, paper_size)
+            genMarker(i, dicno, paper_size, fid_len)
 
     print("Combining into %s" % outfile)
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))
     for f in pdfs:
         os.remove(f)
 
-    print('\033[91m' + """After printing, please make sure that the long lines around the marker are
-EXACTLY 14.0 cm long. This is required for accurate position estimation.""" + '\033[0m')
+    print('\033[91m' + """After printing, please make sure that the long lines around the marker are 
+          EXACTLY %3.1f cm long. This is required for accurate position estimation."""  % fid_len + '\033[0m')
 

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
                         help='dictionary to generate from')
     parser.add_argument('--paper-size', dest='paper_size', action='store',
                         default='letter', help='paper size to use (letter or a4)')
-    parser.add_argument('--fid-len', type=float, dest='fid_len', action="store",
+    parser.add_argument('--fiducial-length', type=float, dest='fid_len', action="store",
                         default="14.0", help="fiducial side length in centimeter")
 
     args = parser.parse_args()

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -21,6 +21,7 @@ else:
 
 import cv2
 import cv2.aruco as aruco
+import cairosvg
 
 """
 Generate a PDF file containaing one or more fiducial marker for printing
@@ -90,16 +91,15 @@ def genMarker(i, dicno, paper_size):
     img = aruco.drawMarker(aruco_dict, i, 2000)
     cv2.imwrite("/tmp/marker%d.png" % i, img)
     svg = genSvg(i, dicno, paper_size)
-    cairo = subprocess.Popen(('cairosvg', '-f', 'pdf', '-o', '/tmp/marker%d.pdf' % i, '/dev/stdin'), stdin=subprocess.PIPE)
-    cairo.communicate(input=bytes(svg, 'utf-8'))
-    # This way is faster than subprocess, but causes problems when cairosvg is installed from pip
-    # because newer versions only support python3, and opencv3 from ros does not
-    # cairosvg.svg2pdf(bytestring=svg, write_to='/tmp/marker%d.pdf' % i)
+    cairosvg.svg2pdf(bytestring=svg, write_to='/tmp/marker%d.pdf' % i)
+    # Old slower method using subprocess for SVG to PDF conversion
+    # cairo = subprocess.Popen(('cairosvg', '-f', 'pdf', '-o', '/tmp/marker%d.pdf' % i, '/dev/stdin'), stdin=subprocess.PIPE)
+    # cairo.communicate(input=bytes(svg, 'utf-8'))
     os.remove("/tmp/marker%d.png" % i)
 
 if __name__ == "__main__":
     checkCmd("pdfunite", "poppler-utils")
-    checkCmd("cairosvg", "cairosvg") # Installed from apt
+    checkCmd("cairosvg", "python3-cairosvg")
 
 
     parser = argparse.ArgumentParser(description='Generate Aruco Markers.')

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -146,5 +146,5 @@ if __name__ == "__main__":
         os.remove(f)
 
     print('\033[91m' + """After printing, please make sure that the long lines around the marker are 
-          EXACTLY %3.1f cm long. This is required for accurate position estimation."""  % fid_len + '\033[0m')
+EXACTLY %3.1f cm long. This is required for accurate position estimation."""  % fid_len + '\033[0m')
 

--- a/aruco_detect/scripts/create_markers.py
+++ b/aruco_detect/scripts/create_markers.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os, sys, argparse
 import subprocess
-import imp, importlib
+import importlib.machinery
 
 # Hack if a user has 'em' instead of 'empy' installed with pip
 # If the module em doesn't have the expand function use the full path
@@ -10,12 +10,13 @@ em = None
 for path in sys.path:
     filename = os.path.join(path, 'em.py')
     if os.path.exists(filename):
-         em = imp.load_source('em', filename)
+         em_loader = importlib.machinery.SourceFileLoader('em', filename)
+         em = em_loader.load_module()
          if "expand" in dir(em):
              break
 # For-else: else is called if loop doesn't break 
 else:
-    print "ERROR: could not find module em, please sudo apt install python-empy"
+    print("ERROR: could not find module em, please sudo apt install python-empy")
     exit(2)
 
 import cv2
@@ -28,8 +29,8 @@ Generate a PDF file containaing one or more fiducial marker for printing
 def checkCmd(cmd, package):
     rc = os.system("which %s > /dev/null" % cmd)
     if rc != 0:
-        print """This utility requires %s. It can be installed by typing:
-    sudo apt install %s""" % (cmd, package)
+        print("""This utility requires %s. It can be installed by typing:
+    sudo apt install %s""" % (cmd, package))
         sys.exit(1)
      
 def genSvg(id, dicno, paper_size):
@@ -83,14 +84,14 @@ def genSvg(id, dicno, paper_size):
 """, {"id": id, "dicno": dicno, "paper_width": paper_size[0], "paper_height": paper_size[1], "fid_len": 140.0})
 
 def genMarker(i, dicno, paper_size):
-    print " Marker %d\r" % i,
+    print(" Marker %d\r" % i)
     sys.stdout.flush()
     aruco_dict = aruco.Dictionary_get(dicno)
     img = aruco.drawMarker(aruco_dict, i, 2000)
     cv2.imwrite("/tmp/marker%d.png" % i, img)
     svg = genSvg(i, dicno, paper_size)
     cairo = subprocess.Popen(('cairosvg', '-f', 'pdf', '-o', '/tmp/marker%d.pdf' % i, '/dev/stdin'), stdin=subprocess.PIPE)
-    cairo.communicate(input=svg)
+    cairo.communicate(input=bytes(svg, 'utf-8'))
     # This way is faster than subprocess, but causes problems when cairosvg is installed from pip
     # because newer versions only support python3, and opencv3 from ros does not
     # cairosvg.svg2pdf(bytestring=svg, write_to='/tmp/marker%d.pdf' % i)
@@ -98,7 +99,7 @@ def genMarker(i, dicno, paper_size):
 
 if __name__ == "__main__":
     checkCmd("pdfunite", "poppler-utils")
-    checkCmd("cairosvg", "python-cairosvg")
+    checkCmd("cairosvg", "cairosvg") # Installed from apt
 
 
     parser = argparse.ArgumentParser(description='Generate Aruco Markers.')
@@ -135,11 +136,11 @@ if __name__ == "__main__":
         for i in markers:
             genMarker(i, dicno, paper_size)
 
-    print "Combining into %s" % outfile
+    print("Combining into %s" % outfile)
     os.system("pdfunite %s %s" % (" ".join(pdfs), outfile))
     for f in pdfs:
         os.remove(f)
 
-    print '\033[91m' + """After printing, please make sure that the long lines around the marker are
-EXACTLY 14.0 cm long. This is required for accurate position estimation.""" + '\033[0m'
+    print('\033[91m' + """After printing, please make sure that the long lines around the marker are
+EXACTLY 14.0 cm long. This is required for accurate position estimation.""" + '\033[0m')
 

--- a/aruco_gazebo/scripts/aruco.py
+++ b/aruco_gazebo/scripts/aruco.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 from __future__ import print_function
 
 import sys


### PR DESCRIPTION
The main notable changes are given below:

The `create_marker.py` script is now updated to work with Python 3.

Added a new argument to specify the side length of the marker in centimetres.
`rosrun aruco_detect create_markers.py 0 5 output.pdf --fiducial-length 9.0`
Tested and measured the generated markers and it works.

Removed the need to use `subprocess` for `cairosvg` which makes the PDF
generation faster. `python3-cairosvg` can be installed from Pip.