### PR TITLE
Remove unused parts from fiducial_slam

### DIFF
--- a/fiducial_slam/launch/fiducial_slam.launch
+++ b/fiducial_slam/launch/fiducial_slam.launch
@@ -10,12 +10,10 @@
   <arg name="tf_publish_interval" default="0.2"/>
   <arg name="future_date_transforms" default="0.0"/>
   <arg name="publish_6dof_pose" default="false"/>
-  <arg name="fiducial_len" default="0.14"/>
   <arg name="systematic_error" default="0.01"/>
-  <arg name="do_pose_estimation" default="false"/>
   <arg name="covariance_diagonal" default=""/>
 
-  <node type="fiducial_slam" pkg="fiducial_slam" output="screen" 
+  <node type="fiducial_slam" pkg="fiducial_slam" output="screen"
     name="fiducial_slam">
     <param name="map_file" value="$(env HOME)/.ros/slam/map.txt" />
     <param name="map_frame" value="$(arg map_frame)" />
@@ -25,9 +23,7 @@
     <param name="tf_publish_interval" value="$(arg tf_publish_interval)" />
     <param name="future_date_transforms" value="$(arg future_date_transforms)" />
     <param name="publish_6dof_pose" value="$(arg publish_6dof_pose)" />
-    <param name="do_pose_estimation" value="$(arg do_pose_estimation)"/>
     <param name="sum_error_in_quadrature" value="true"/>
-    <param name="fiducial_len" value="$(arg fiducial_len)"/>
     <rosparam param="covariance_diagonal" subst_value="True">$(arg covariance_diagonal)</rosparam>
     <remap from="/camera_info" to="$(arg camera)/camera_info"/>
 

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -65,8 +65,6 @@ class FiducialSlam {
 private:
     ros::Subscriber ft_sub;
 
-    ros::Subscriber verticesSub;
-    ros::Subscriber cameraInfoSub;
     ros::Publisher ftPub;
 
     bool use_fiducial_area_as_weight;

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -65,8 +65,6 @@ class FiducialSlam {
 private:
     ros::Subscriber ft_sub;
 
-    ros::Publisher ftPub;
-
     bool use_fiducial_area_as_weight;
     double weighting_scale;
 
@@ -106,7 +104,6 @@ void FiducialSlam::transformCallback(const fiducial_msgs::FiducialTransformArray
 }
 
 FiducialSlam::FiducialSlam(ros::NodeHandle &nh) : fiducialMap(nh) {
-    bool doPoseEstimation;
 
     // If set, use the fiducial area in pixels^2 as an indication of the
     // 'goodness' of it. This will favor fiducials that are close to the
@@ -116,18 +113,7 @@ FiducialSlam::FiducialSlam(ros::NodeHandle &nh) : fiducialMap(nh) {
     // Scaling factor for weighing
     nh.param<double>("weighting_scale", weighting_scale, 1e9);
 
-    nh.param("do_pose_estimation", doPoseEstimation, false);
-
-    if (doPoseEstimation) {
-        double fiducialLen, errorThreshold;
-        nh.param<double>("fiducial_len", fiducialLen, 0.14);
-        nh.param<double>("pose_error_theshold", errorThreshold, 1.0);
-
-        ftPub = ros::Publisher(
-            nh.advertise<fiducial_msgs::FiducialTransformArray>("/fiducial_transforms", 1));
-    } else {
-        ft_sub = nh.subscribe("/fiducial_transforms", 1, &FiducialSlam::transformCallback, this);
-    }
+    ft_sub = nh.subscribe("/fiducial_transforms", 1, &FiducialSlam::transformCallback, this);
 
     ROS_INFO("Fiducial Slam ready");
 }


### PR DESCRIPTION
These seem to be obsolete.


```
ros::Subscriber verticesSub;
ros::Subscriber cameraInfoSub;
```
are not used.

---

```
if (doPoseEstimation) {
        double fiducialLen, errorThreshold;
        nh.param<double>("fiducial_len", fiducialLen, 0.14);
        nh.param<double>("pose_error_theshold", errorThreshold, 1.0);

        ftPub = ros::Publisher(
            nh.advertise<fiducial_msgs::FiducialTransformArray>("/fiducial_transforms", 1));
    }
```
looks like an artifact. Maybe aruco_detect was used with copy+paste at the beginning? Also `do_pose_estimation` is not documented at http://wiki.ros.org/fiducial_slam