### PR TITLE
Add missing dependencies on transport plugins

### DIFF
--- a/aruco_detect/package.xml
+++ b/aruco_detect/package.xml
@@ -12,7 +12,10 @@
   <author email="jimv@mrjim.com">Jim Vaughan</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-
+  
+  <depend>compressed_depth_image_transport</depend>
+  <depend>compressed_image_transport</depend>
+  <depend>theora_image_transport</depend>  
   <depend>roscpp</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
## Description

Just noticed that aruco_detect does not define any dependencies on packages from [image_transport_plugins](https://github.com/ros-perception/image_transport_plugins/blob/noetic-devel/image_transport_plugins/package.xml) but we use them when using other transport formats differents than image_raw (theora, compressed)  

## Oveview 

Add dependencies on packages from  [image_transport_plugins](https://github.com/ros-perception/image_transport_plugins/blob/noetic-devel/image_transport_plugins/package.xml)