### PR TITLE
Added verbosity option for printouts

### DIFF
--- a/aruco_detect/launch/aruco_detect.launch
+++ b/aruco_detect/launch/aruco_detect.launch
@@ -11,6 +11,7 @@
   <arg name="vis_msgs" default="false"/>
   <arg name="ignore_fiducials" default="" />
   <arg name="fiducial_len_override" default="" />
+  <arg name="verbose" default="false"/>
 
   <node pkg="aruco_detect" name="aruco_detect"
     type="aruco_detect" output="screen" respawn="false">
@@ -22,6 +23,7 @@
     <param name="vis_msgs" value="$(arg vis_msgs)"/>
     <param name="ignore_fiducials" value="$(arg ignore_fiducials)"/>
     <param name="fiducial_len_override" value="$(arg fiducial_len_override)"/>
+    <param name="verbose" value="$(arg verbose)"/>
     <remap from="camera/compressed" 
         to="$(arg camera)/$(arg image)/$(arg transport)"/>
     <remap from="camera_info" to="$(arg camera)/camera_info"/>


### PR DESCRIPTION
To get the crazy amount of prinouts under control I've added a new boolean param named `verbose`, which is false by default and reduces the amount of printing to only "Detected x markers" and only if x changes. Setting it to true restores the old functionality.

I've also fixed some indents, because dear lord what the hell. We had some 8 space tabs in there which rendered at the usual 4 space size break the entire thing so far up that it's unreadable.