### PR TITLE
[Kinetic] Use newer constant for imread in aruco tests

### DIFF
--- a/aruco_detect/test/aruco_images_test.cpp
+++ b/aruco_detect/test/aruco_images_test.cpp
@@ -41,7 +41,7 @@ protected:
   virtual void TearDown() { delete it;}
 
   void publish_image(std::string file) {
-    cv::Mat image = cv::imread(image_directory+file, CV_LOAD_IMAGE_COLOR);
+    cv::Mat image = cv::imread(image_directory+file, cv::IMREAD_COLOR);
     cv::waitKey(30);
     sensor_msgs::ImagePtr msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", image).toImageMsg();
     image_pub.publish(msg);


### PR DESCRIPTION
This is required for compiling under OpenCV 4.2. Closes #255 