### PR TITLE
Added pose_publish_rate which controls the rate of /fiducial_pose

### DIFF
--- a/fiducial_slam/launch/fiducial_slam.launch
+++ b/fiducial_slam/launch/fiducial_slam.launch
@@ -10,6 +10,7 @@
   <arg name="tf_publish_interval" default="0.2"/>
   <arg name="future_date_transforms" default="0.0"/>
   <arg name="publish_6dof_pose" default="false"/>
+  <arg name="pose_publish_rate" default="20"/>
   <arg name="systematic_error" default="0.01"/>
   <arg name="covariance_diagonal" default=""/>
 
@@ -23,6 +24,7 @@
     <param name="tf_publish_interval" value="$(arg tf_publish_interval)" />
     <param name="future_date_transforms" value="$(arg future_date_transforms)" />
     <param name="publish_6dof_pose" value="$(arg publish_6dof_pose)" />
+    <param name="pose_publish_rate" value="$(arg pose_publish_rate)" />
     <param name="sum_error_in_quadrature" value="true"/>
     <rosparam param="covariance_diagonal" subst_value="True">$(arg covariance_diagonal)</rosparam>
     <remap from="/camera_info" to="$(arg camera)/camera_info"/>

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -72,6 +72,7 @@ private:
 
 public:
     Map fiducialMap;
+    int pose_publish_rate;
     FiducialSlam(ros::NodeHandle &nh);
 };
 
@@ -112,6 +113,7 @@ FiducialSlam::FiducialSlam(ros::NodeHandle &nh) : fiducialMap(nh) {
     nh.param<bool>("use_fiducial_area_as_weight", use_fiducial_area_as_weight, false);
     // Scaling factor for weighing
     nh.param<double>("weighting_scale", weighting_scale, 1e9);
+    nh.param<int>("pose_publish_rate", pose_publish_rate, 20);
 
     ft_sub = nh.subscribe("/fiducial_transforms", 1, &FiducialSlam::transformCallback, this);
 
@@ -133,7 +135,7 @@ int main(int argc, char **argv) {
     node = make_unique<FiducialSlam>(nh);
     signal(SIGINT, mySigintHandler);
 
-    ros::Rate r(20);
+    ros::Rate r(node->pose_publish_rate);
     while (ros::ok()) {
         ros::spinOnce();
         r.sleep();


### PR DESCRIPTION
Hi

The rate for publishing the fiducial_pose is hard_coded to 20 Hz. This limits the possible speeds when controlling by directly acquiring the fiducials position. This feature makes it possible to adjust the publishing speed through a rosparam. 