### PR TITLE
Update DetectorParams.cfg to accept default for `maxMarkerPerimeterRate`

### DIFF
--- a/aruco_detect/cfg/DetectorParams.cfg
+++ b/aruco_detect/cfg/DetectorParams.cfg
@@ -71,7 +71,7 @@ gen.add("minMarkerPerimeterRate",                 double_t, 0,
 
 gen.add("maxMarkerPerimeterRate",                 double_t, 0,
         "Determine maximum perimeter for marker contour to be detected. This is defined as a rate respect to the maximum dimension of the input image",
-        4.0, 0, 1)
+        4.0, 0, 4)
 
 gen.add("minOtsuStdDev",                          double_t, 0,
         "Minimun standard deviation in pixels values during the decodification step to apply Otsu thresholding (otherwise, all the bits are set to 0 or 1 depending on mean higher than 128 or not)",


### PR DESCRIPTION
The current setting doesn't allow `maxMarkerPerimeterRate` to be set to its default value 4,
because the dynamic config maxes out at 1. For future, it might be better to make this
a function of marker size explicitly.