### PR TITLE
Add missing tf dependency.

### DIFF
--- a/aruco_detect/CMakeLists.txt
+++ b/aruco_detect/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_geometry_msgs
   tf2_ros
   tf2
+  tf
   visualization_msgs
   vision_msgs
   image_transport

--- a/aruco_detect/package.xml
+++ b/aruco_detect/package.xml
@@ -20,6 +20,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2</depend>
+  <depend>tf</depend>
   <depend>visualization_msgs</depend>
   <depend>vision_msgs</depend>
   <depend>image_transport</depend>

--- a/fiducial_slam/CMakeLists.txt
+++ b/fiducial_slam/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_geometry_msgs
   tf2_ros
   tf2
+  tf
   visualization_msgs
   cv_bridge
   sensor_msgs

--- a/fiducial_slam/package.xml
+++ b/fiducial_slam/package.xml
@@ -17,6 +17,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2</depend>
+  <depend>tf</depend>
   <depend>visualization_msgs</depend>
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
aruco_detect and fiducial_slam require the tf/transform_datatypes.h
This adds the dependency on tf.

![image](https://user-images.githubusercontent.com/20051567/155210407-76ebf841-2b80-4f25-92e9-fcd63e22df6e.png)
