### PR TITLE
Boost placeholders, use newer C++ and std::make_unique to build Ubuntu 22.04

### DIFF
--- a/aruco_detect/CMakeLists.txt
+++ b/aruco_detect/CMakeLists.txt
@@ -30,8 +30,6 @@ catkin_package(INCLUDE_DIRS DEPENDS OpenCV)
 ## Build ##
 ###########
 
-add_definitions(-std=c++11)
-
 include_directories(${catkin_INCLUDE_DIRS})
 include_directories(${OpenCV_INCLUDE_DIRS})
 
@@ -67,9 +65,6 @@ install(DIRECTORY launch/
 if(CATKIN_ENABLE_TESTING)
         find_package(rostest REQUIRED)
 
-        # Tests need c++11
-        add_definitions(-std=c++11)
-        
         add_rostest_gtest(aruco_images_test 
           test/aruco_images.test 
           test/aruco_images_test.cpp)

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -684,7 +684,7 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh)
     service_enable_detections = nh.advertiseService("enable_detections",
                         &FiducialsNode::enableDetectionsCallback, this);
 
-    callbackType = boost::bind(&FiducialsNode::configCallback, this, _1, _2);
+    callbackType = boost::bind(&FiducialsNode::configCallback, this, boost::placeholders::_1, boost::placeholders::_2);
     configServer.setCallback(callbackType);
 
     pnh.param<double>("adaptiveThreshConstant", detectorParams->adaptiveThreshConstant, 7);

--- a/fiducial_slam/CMakeLists.txt
+++ b/fiducial_slam/CMakeLists.txt
@@ -36,8 +36,6 @@ generate_messages(
 ## Build ##
 ###########
 
-add_definitions(-std=c++11)
-
 include_directories(${catkin_INCLUDE_DIRS} include)
 catkin_package(INCLUDE_DIRS include
   DEPENDS OpenCV)
@@ -78,9 +76,6 @@ if(CATKIN_ENABLE_TESTING)
         find_package(catkin REQUIRED COMPONENTS
           rostest roscpp sensor_msgs tf2_ros image_transport cv_bridge)
 
-        # Tests need c++11
-        add_definitions(-std=c++11)
-	
 	catkin_add_gtest(transform_var_test test/transform_var_test.cpp src/transform_with_variance)
 	target_link_libraries(transform_var_test ${catkin_LIBRARIES})
 

--- a/fiducial_slam/include/fiducial_slam/helpers.h
+++ b/fiducial_slam/include/fiducial_slam/helpers.h
@@ -1,12 +1,6 @@
 #include <cmath>
 #include <memory>
 
-// Basic make_unique helper function, similar to C++14 one
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
 // Degrees to radians
 constexpr double deg2rad(double deg) { return deg * M_PI / 180.0; }
 

--- a/fiducial_slam/src/fiducial_slam.cpp
+++ b/fiducial_slam/src/fiducial_slam.cpp
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
     ros::init(argc, argv, "fiducial_slam", ros::init_options::NoSigintHandler);
     ros::NodeHandle nh("~");
 
-    node = make_unique<FiducialSlam>(nh);
+    node = std::make_unique<FiducialSlam>(nh);
     signal(SIGINT, mySigintHandler);
 
     ros::Rate r(node->pose_publish_rate);

--- a/fiducial_slam/src/map.cpp
+++ b/fiducial_slam/src/map.cpp
@@ -83,7 +83,7 @@ Map::Map(ros::NodeHandle &nh) : tfBuffer(ros::Duration(30.0)) {
     havePose = false;
     fiducialToAdd = -1;
 
-    listener = make_unique<tf2_ros::TransformListener>(tfBuffer);
+    listener = std::make_unique<tf2_ros::TransformListener>(tfBuffer);
 
     robotPosePub =
         ros::Publisher(nh.advertise<geometry_msgs::PoseWithCovarianceStamped>("/fiducial_pose", 1));


### PR DESCRIPTION
boost::placeholders::_1/2_ replaces the deprecated _1/_2 

C++17 (the default in 22.04) is needed to avoid log4cxx build errors, since this is the noetic branch C++14 will be used by default there and should still work, shouldn't be pinned back to C++11.