### PR TITLE
vision_msgs in stag_detect CMakelists.txt and use default C++ instead of C++11

### DIFF
--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -95,6 +95,8 @@ class FiducialsNode {
 
     double fiducial_len;
 
+    std::string tf_prefix;
+
     bool doPoseEstimation;
     bool haveCamInfo;
     bool publishFiducialTf;
@@ -510,7 +512,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                         ts.transform.rotation.z = q.z();
                         ts.header.frame_id = frameId;
                         ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = "fiducial_" + std::to_string(ids[i]);
+                        ts.child_frame_id = tf_prefix + std::to_string(ids[i]);
                         broadcaster.sendTransform(ts);
                     }
                     else {
@@ -518,7 +520,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                         ts.transform = ft.transform;
                         ts.header.frame_id = frameId;
                         ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = "fiducial_" + std::to_string(ft.fiducial_id);
+                        ts.child_frame_id = tf_prefix + std::to_string(ft.fiducial_id);
                         broadcaster.sendTransform(ts);
                     }
                 }
@@ -613,6 +615,8 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh)
     pnh.param<bool>("publish_fiducial_tf", publishFiducialTf, true);
     pnh.param<bool>("vis_msgs", vis_msgs, false);
     pnh.param<bool>("verbose", verbose, false);
+
+    pnh.param<std::string>("tf_prefix", tf_prefix, "fiducial_");
 
     std::string str;
     std::vector<std::string> strs;

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -464,6 +464,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                 tf2::Quaternion q;
                 if (vis_msgs) {
                     vision_msgs::Detection2D vm;
+                    vm.header = vma.header;
                     vision_msgs::ObjectHypothesisWithPose vmh;
                     vmh.id = ids[i];
                     vmh.score = exp(-2 * object_error); // [0, infinity] -> [1,0]

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -663,7 +663,7 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh)
         }
     }
 
-    image_pub = it.advertise("/fiducial_images", 1);
+    image_pub = it.advertise("fiducial_images", 1);
 
     vertices_pub = nh.advertise<fiducial_msgs::FiducialArray>("fiducial_vertices", 1);
 

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -503,6 +503,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
 
                 // Publish tf for the fiducial relative to the camera
                 if (publishFiducialTf) {
+                    const auto frame = msg->header.frame_id + "_" + tf_prefix + std::to_string(ids[i]);
                     if (vis_msgs) {
                         geometry_msgs::TransformStamped ts;
                         ts.transform.translation.x = tvecs[i][0];
@@ -514,7 +515,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                         ts.transform.rotation.z = q.z();
                         ts.header.frame_id = frameId;
                         ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = tf_prefix + std::to_string(ids[i]);
+                        ts.child_frame_id = frame;
                         broadcaster.sendTransform(ts);
                     }
                     else {
@@ -522,7 +523,7 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                         ts.transform = ft.transform;
                         ts.header.frame_id = frameId;
                         ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = tf_prefix + std::to_string(ft.fiducial_id);
+                        ts.child_frame_id = frame;
                         broadcaster.sendTransform(ts);
                     }
                 }

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -44,6 +44,7 @@
 #include <visualization_msgs/Marker.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/Image.h>
 #include <sensor_msgs/image_encodings.h>
 #include <dynamic_reconfigure/server.h>
 #include <std_srvs/SetBool.h>
@@ -113,7 +114,7 @@ class FiducialsNode {
     ros::NodeHandle nh;
     ros::NodeHandle pnh;
 
-    image_transport::Publisher image_pub;
+    ros::Publisher image_pub;
 
     // log spam prevention
     int prev_detected_count;
@@ -663,7 +664,7 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh)
         }
     }
 
-    image_pub = it.advertise("fiducial_images", 1);
+    image_pub = nh.advertise<sensor_msgs::Image>("fiducial_images", 1);
 
     vertices_pub = nh.advertise<fiducial_msgs::FiducialArray>("fiducial_vertices", 1);
 

--- a/aruco_detect/src/aruco_detect.cpp
+++ b/aruco_detect/src/aruco_detect.cpp
@@ -428,8 +428,8 @@ void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr & msg)
                                       reprojectionError);
 
             for (size_t i=0; i<ids.size(); i++) {
-                aruco::drawAxis(cv_ptr->image, cameraMatrix, distortionCoeffs,
-                                rvecs[i], tvecs[i], (float)fiducial_len);
+                cv::drawFrameAxes(cv_ptr->image, cameraMatrix, distortionCoeffs,
+                                  rvecs[i], tvecs[i], (float)fiducial_len);
                 if(verbose){
                     ROS_INFO("Detected id %d T %.2f %.2f %.2f R %.2f %.2f %.2f", ids[i],
                          tvecs[i][0], tvecs[i][1], tvecs[i][2],

--- a/stag_detect/CMakeLists.txt
+++ b/stag_detect/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   fiducial_msgs
   dynamic_reconfigure
+  vision_msgs
 )
 
 find_package(OpenCV REQUIRED)
@@ -35,8 +36,6 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-
-add_definitions(-std=c++11)
 
 include_directories(
   include

--- a/stag_detect/include/stag_ros/stag_nodelet.h
+++ b/stag_detect/include/stag_ros/stag_nodelet.h
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 #pragma once
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <nodelet/nodelet.h>
 


### PR DESCRIPTION
Use default C++ instead of C++11 which avoids '‘std::shared_mutex’ is only available from C++17 onwards' error on 22.04