### PR TITLE
Add per-marker size configuration for STag pose estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ ceiling fiducials.
 ### Floor fiducials
 
 You can put the fiducials also on the floor and direct the camera downwards. This is used in EZ-Map and Conveyorbot as additional source of localization data.
+
+## TODO
+
+- Extend the STag marker configuration so each tag can optionally store a known world-frame pose (`x`, `y`, `z`) for future global robot pose estimation.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# TODO
+
+- Add optional world-frame tag pose entries to the STag config so the system can store known `x`, `y`, `z` positions and later derive robot pose from detected tags.

--- a/stag_detect/CMakeLists.txt
+++ b/stag_detect/CMakeLists.txt
@@ -4,7 +4,6 @@ project(stag_detect)
 # Required dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(camera_info_manager REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -16,6 +15,8 @@ find_package(image_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(fiducial_msgs REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(dynamic_reconfigure QUIET) # Not fully supported in ROS2, alternatives may be needed
 find_package(Threads REQUIRED)
@@ -62,7 +63,7 @@ ament_target_dependencies(stag_core
 # Declare the executable
 add_executable(stag_detect src/stag_ros/stag_detect.cpp)
 ament_target_dependencies(stag_detect
-  camera_info_manager
+  ament_index_cpp
   cv_bridge
   geometry_msgs
   tf2_geometry_msgs
@@ -80,6 +81,7 @@ ament_target_dependencies(stag_detect
 target_link_libraries(stag_detect
   stag_core
   ${OpenCV_LIBS}
+  yaml-cpp
 )
 
 # Install targets

--- a/stag_detect/README.md
+++ b/stag_detect/README.md
@@ -6,6 +6,32 @@ This package consist of files for generating and launching STag marker related s
 
 The stag_detect node finds STag markers in images stream and estimates 3D transforms from the camera to the fiducials.
 
+## Per-marker size configuration
+
+The node now supports an optional `config_file` parameter for per-marker size lookup.
+The file is a YAML document with one default size and a list of marker-specific overrides:
+
+```yaml
+default_marker_size: 0.18
+markers:
+  - id: 8
+    size: 0.08
+  - id: 18
+    size: 0.14
+```
+
+Launch example:
+
+```bash
+ros2 launch stag_detect stag_detect.launch.py marker_size:=0.18 config_file:=cfg/marker_sizes.yaml
+```
+
+If a detected marker id exists in the file, that size is used for pose estimation. Otherwise the node falls back to `marker_size`.
+
+## TODO
+
+- Extend the YAML config to optionally store world-frame tag positions for future global pose estimation.
+
 Based on:
 - https://github.com/usrl-uofsc/stag_ros
 - https://github.com/bbenligiray/stag

--- a/stag_detect/cfg/marker_sizes.yaml
+++ b/stag_detect/cfg/marker_sizes.yaml
@@ -1,0 +1,6 @@
+default_marker_size: 0.18
+markers:
+  - id: 8
+    size: 0.08
+  - id: 18
+    size: 0.14

--- a/stag_detect/include/stag_ros/common.hpp
+++ b/stag_detect/include/stag_ros/common.hpp
@@ -35,11 +35,15 @@ struct Common {
                              const std::vector<cv::Point3d> &world,
                              cv::Mat &output, const cv::Mat &cameraMatrix,
                              const cv::Mat &distortionMatrix) {
-    if (img.empty() or world.empty()) return;
+    if (img.size() != 4 || world.size() != 4) return;
     cv::Mat rVec, rMat, tVec;
-    // optimize for 5 planar points
-    // possibly choose to reduce to the 4 for use with advanced algos
-    cv::solvePnP(world, img, cameraMatrix, distortionMatrix, rVec, tVec);
+    // Square fiducials are planar and have a dedicated PnP solver that is
+    // more stable than the generic iterative solver for this geometry.
+    bool solved = cv::solvePnP(world, img, cameraMatrix, distortionMatrix,
+                               rVec, tVec, false, cv::SOLVEPNP_IPPE_SQUARE);
+    if (!solved) {
+      cv::solvePnP(world, img, cameraMatrix, distortionMatrix, rVec, tVec);
+    }
     cv::Rodrigues(rVec, rMat);
     rMat.convertTo(output.colRange(0, 3), CV_64F);
     tVec.convertTo(output.col(3), CV_64F);

--- a/stag_detect/include/stag_ros/stag_node.h
+++ b/stag_detect/include/stag_ros/stag_node.h
@@ -28,7 +28,8 @@ SOFTWARE.
 #include "rclcpp/rclcpp.hpp"
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
-#include "camera_info_manager/camera_info_manager.hpp"
+#include <map>
+#include <string>
 
 // ROS msgs
 #include "sensor_msgs/image_encodings.hpp"
@@ -55,13 +56,16 @@ class StagNode : public rclcpp::Node {
 
   // Functions
   void loadParameters();
-  // bool getTagIndex(const int id, int &tag_index);
+  void loadMarkerSizeConfig();
+  float getMarkerSizeForId(int marker_id) const;
 
   // STag handle
   Stag *stag;
   int stag_library;
   int error_correction;
   float marker_size;
+  std::string config_file;
+  std::map<int, float> marker_sizes_by_id;
 
   // ROS 2 Interfaces
   image_transport::Subscriber imageSub;

--- a/stag_detect/include/stag_ros/stag_node.h
+++ b/stag_detect/include/stag_ros/stag_node.h
@@ -30,7 +30,6 @@ SOFTWARE.
 #include "image_transport/image_transport.hpp"
 #include <filesystem>
 #include <map>
-#include <set>
 #include <string>
 
 // ROS msgs
@@ -60,8 +59,6 @@ class StagNode : public rclcpp::Node {
   void loadParameters();
   void loadMarkerSizeConfig();
   float getMarkerSizeForId(int marker_id) const;
-  void logMarkerSizeSelection(int marker_id, float marker_size_value, bool is_configured_size);
-  std::filesystem::path resolveMarkerConfigPath() const;
 
   // STag handle
   Stag *stag;
@@ -70,9 +67,6 @@ class StagNode : public rclcpp::Node {
   float marker_size;
   std::string config_file;
   std::map<int, float> marker_sizes_by_id;
-  std::set<int> logged_marker_size_ids;
-  std::set<int> warned_missing_marker_ids;
-  bool marker_config_loaded;
 
   // ROS 2 Interfaces
   image_transport::Subscriber imageSub;

--- a/stag_detect/include/stag_ros/stag_node.h
+++ b/stag_detect/include/stag_ros/stag_node.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
 #include <map>
+#include <set>
 #include <string>
 
 // ROS msgs
@@ -58,6 +59,7 @@ class StagNode : public rclcpp::Node {
   void loadParameters();
   void loadMarkerSizeConfig();
   float getMarkerSizeForId(int marker_id) const;
+  void logMarkerSizeSelection(int marker_id, float marker_size_value, bool is_configured_size);
 
   // STag handle
   Stag *stag;
@@ -66,6 +68,8 @@ class StagNode : public rclcpp::Node {
   float marker_size;
   std::string config_file;
   std::map<int, float> marker_sizes_by_id;
+  std::set<int> logged_marker_size_ids;
+  std::set<int> warned_missing_marker_ids;
 
   // ROS 2 Interfaces
   image_transport::Subscriber imageSub;

--- a/stag_detect/include/stag_ros/stag_node.h
+++ b/stag_detect/include/stag_ros/stag_node.h
@@ -28,6 +28,7 @@ SOFTWARE.
 #include "rclcpp/rclcpp.hpp"
 #include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
+#include <filesystem>
 #include <map>
 #include <set>
 #include <string>
@@ -60,6 +61,7 @@ class StagNode : public rclcpp::Node {
   void loadMarkerSizeConfig();
   float getMarkerSizeForId(int marker_id) const;
   void logMarkerSizeSelection(int marker_id, float marker_size_value, bool is_configured_size);
+  std::filesystem::path resolveMarkerConfigPath() const;
 
   // STag handle
   Stag *stag;
@@ -70,6 +72,7 @@ class StagNode : public rclcpp::Node {
   std::map<int, float> marker_sizes_by_id;
   std::set<int> logged_marker_size_ids;
   std::set<int> warned_missing_marker_ids;
+  bool marker_config_loaded;
 
   // ROS 2 Interfaces
   image_transport::Subscriber imageSub;

--- a/stag_detect/launch/stag_detect.launch.py
+++ b/stag_detect/launch/stag_detect.launch.py
@@ -1,14 +1,13 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
-import os
+from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
-    # Find the path to the stag_detect package
-    stag_detect_share_dir = get_package_share_directory('stag_detect')
-    single_yaml_path = os.path.join(stag_detect_share_dir, 'cfg', 'single.yaml')
+    package_share = FindPackageShare('stag_detect')
+    single_yaml_path = PathJoinSubstitution([package_share, 'cfg', 'single.yaml'])
 
     # Declare the launch argument
     fiducial_transform_topic_arg = DeclareLaunchArgument(
@@ -23,6 +22,12 @@ def generate_launch_description():
         description='Size of the fiducial marker in meters'
     )
 
+    config_file_arg = DeclareLaunchArgument(
+        'config_file',
+        default_value='',
+        description='Optional relative path inside the stag_detect share directory to a YAML file with per-marker sizes'
+    )
+
     # Node definition
     stag_detect_node = Node(
         package='stag_detect',
@@ -31,6 +36,7 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'marker_size': LaunchConfiguration('marker_size')},
+            {'config_file': LaunchConfiguration('config_file')},
             {'stag_library': 11},
             {'image_topic': "/camera/image_raw/compressed"},
             {'is_compressed': True},
@@ -45,5 +51,6 @@ def generate_launch_description():
     return LaunchDescription([
         fiducial_transform_topic_arg,
         marker_size_arg,
+        config_file_arg,
         stag_detect_node,
     ])

--- a/stag_detect/launch/stag_detect.launch.py
+++ b/stag_detect/launch/stag_detect.launch.py
@@ -1,12 +1,9 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
-import os
 
 def generate_launch_description():
     package_share = get_package_share_directory('stag_detect')
@@ -31,36 +28,28 @@ def generate_launch_description():
         description='Optional relative path inside the stag_detect share directory to a YAML file with per-marker sizes'
     )
 
-    def create_stag_node(context):
-        config_file = LaunchConfiguration('config_file').perform(context)
-        if config_file and not os.path.isabs(config_file):
-            resolved_config_file = os.path.join(package_share, config_file)
-        else:
-            resolved_config_file = config_file
-
-        stag_detect_node = Node(
-            package='stag_detect',
-            executable='stag_detect',
-            name='stag_detect',
-            output='screen',
-            parameters=[
-                {'marker_size': LaunchConfiguration('marker_size')},
-                {'config_file': resolved_config_file},
-                {'stag_library': 11},
-                {'image_topic': "/camera/image_raw/compressed"},
-                {'is_compressed': True},
-                {'camera_info_topic': "/camera/camera_info"},
-                single_yaml_path  # Load parameters from YAML file
-            ],
-            remappings=[
-                ('stag_ros/markers_array', LaunchConfiguration('fiducial_transform_topic'))
-            ],
-        )
-        return [stag_detect_node]
+    stag_detect_node = Node(
+        package='stag_detect',
+        executable='stag_detect',
+        name='stag_detect',
+        output='screen',
+        parameters=[
+            {'marker_size': LaunchConfiguration('marker_size')},
+            {'config_file': LaunchConfiguration('config_file')},
+            {'stag_library': 11},
+            {'image_topic': "/camera/image_raw/compressed"},
+            {'is_compressed': True},
+            {'camera_info_topic': "/camera/camera_info"},
+            single_yaml_path
+        ],
+        remappings=[
+            ('stag_ros/markers_array', LaunchConfiguration('fiducial_transform_topic'))
+        ],
+    )
 
     return LaunchDescription([
         fiducial_transform_topic_arg,
         marker_size_arg,
         config_file_arg,
-        OpaqueFunction(function=create_stag_node),
+        stag_detect_node,
     ])

--- a/stag_detect/launch/stag_detect.launch.py
+++ b/stag_detect/launch/stag_detect.launch.py
@@ -1,12 +1,15 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
+import os
 
 def generate_launch_description():
-    package_share = FindPackageShare('stag_detect')
+    package_share = get_package_share_directory('stag_detect')
     single_yaml_path = PathJoinSubstitution([package_share, 'cfg', 'single.yaml'])
 
     # Declare the launch argument
@@ -28,29 +31,36 @@ def generate_launch_description():
         description='Optional relative path inside the stag_detect share directory to a YAML file with per-marker sizes'
     )
 
-    # Node definition
-    stag_detect_node = Node(
-        package='stag_detect',
-        executable='stag_detect',
-        name='stag_detect',
-        output='screen',
-        parameters=[
-            {'marker_size': LaunchConfiguration('marker_size')},
-            {'config_file': LaunchConfiguration('config_file')},
-            {'stag_library': 11},
-            {'image_topic': "/camera/image_raw/compressed"},
-            {'is_compressed': True},
-            {'camera_info_topic': "/camera/camera_info"},
-            single_yaml_path  # Load parameters from YAML file
-        ],
-        remappings=[
-            ('stag_ros/markers_array', LaunchConfiguration('fiducial_transform_topic'))
-        ],
-    )
+    def create_stag_node(context):
+        config_file = LaunchConfiguration('config_file').perform(context)
+        if config_file and not os.path.isabs(config_file):
+            resolved_config_file = os.path.join(package_share, config_file)
+        else:
+            resolved_config_file = config_file
+
+        stag_detect_node = Node(
+            package='stag_detect',
+            executable='stag_detect',
+            name='stag_detect',
+            output='screen',
+            parameters=[
+                {'marker_size': LaunchConfiguration('marker_size')},
+                {'config_file': resolved_config_file},
+                {'stag_library': 11},
+                {'image_topic': "/camera/image_raw/compressed"},
+                {'is_compressed': True},
+                {'camera_info_topic': "/camera/camera_info"},
+                single_yaml_path  # Load parameters from YAML file
+            ],
+            remappings=[
+                ('stag_ros/markers_array', LaunchConfiguration('fiducial_transform_topic'))
+            ],
+        )
+        return [stag_detect_node]
 
     return LaunchDescription([
         fiducial_transform_topic_arg,
         marker_size_arg,
         config_file_arg,
-        stag_detect_node,
+        OpaqueFunction(function=create_stag_node),
     ])

--- a/stag_detect/package.xml
+++ b/stag_detect/package.xml
@@ -28,8 +28,9 @@
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>fiducial_msgs</depend>
-  <depend>camera_info_manager</depend>
+  <depend>ament_index_cpp</depend>
   <depend>python3-cairosvg</depend>
+  <depend>yaml-cpp</depend>
 
   <!-- Dynamic reconfigure is not directly supported in ROS2 -->
   <!-- <depend>dynamic_reconfigure</depend> Check for ROS2 alternatives or remove if not needed -->

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -308,6 +308,12 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
       Common::publishTransform(transform_msg, markersPub, msg->header,
 			       tag_tf_prefix, std::to_string(markers[i].id), publish_tf, shared_from_this());
 
+      RCLCPP_INFO(
+          this->get_logger(),
+          "Published marker id=%d size=%.3f m position=(x=%.6f, y=%.6f, z=%.6f)",
+          markers[i].id, current_marker_size, transform_msg.translation.x,
+          transform_msg.translation.y, transform_msg.translation.z);
+
 
       vision_msgs::msg::Detection2D markerobj;
       markerobj.header = msg->header;

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -134,9 +134,25 @@ void StagNode::loadMarkerSizeConfig() {
     }
   }
 
+  if (!std::filesystem::exists(config_path)) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Marker config file '%s' does not exist.",
+                 config_path.c_str());
+    return;
+  }
+
+  RCLCPP_INFO(this->get_logger(),
+              "Loading marker size config from '%s'.",
+              config_path.c_str());
+
   try {
     const YAML::Node config = YAML::LoadFile(config_path.string());
-    const YAML::Node markers = config["markers"];
+    YAML::Node config_root = config;
+    if (config["stag_detect"] && config["stag_detect"]["ros__parameters"]) {
+      config_root = config["stag_detect"]["ros__parameters"];
+    }
+
+    const YAML::Node markers = config_root["markers"];
     if (!markers) {
       RCLCPP_WARN(this->get_logger(),
                   "Marker config file '%s' does not contain a 'markers' list. "
@@ -168,7 +184,7 @@ void StagNode::loadMarkerSizeConfig() {
                   marker_id, configured_size);
     }
 
-    if (const YAML::Node default_size = config["default_marker_size"]) {
+    if (const YAML::Node default_size = config_root["default_marker_size"]) {
       const float configured_default_size = default_size.as<float>();
       if (configured_default_size > 0.0f) {
         marker_size = configured_default_size;
@@ -182,7 +198,7 @@ void StagNode::loadMarkerSizeConfig() {
     RCLCPP_INFO(this->get_logger(),
                 "Loaded %zu marker size entries from '%s'. Default marker size is %.3f m.",
                 marker_sizes_by_id.size(), config_path.c_str(), marker_size);
-  } catch (const YAML::Exception &e) {
+  } catch (const std::exception &e) {
     RCLCPP_ERROR(this->get_logger(),
                  "Failed to parse marker config file '%s': %s",
                  config_path.c_str(), e.what());

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -41,7 +41,10 @@ SOFTWARE.
 #include "vision_msgs/msg/detection2_d.hpp"
 #include "vision_msgs/msg/detection2_d_array.hpp"
 #include "vision_msgs/msg/object_hypothesis_with_pose.hpp"
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "yaml-cpp/yaml.h"
 
+#include <filesystem>
 #include <stdexcept>
 #include <iostream>
 #include <stag_ros/common.hpp>
@@ -91,19 +94,99 @@ StagNode::StagNode() : Node("stag_detect") {
 StagNode::~StagNode() { delete stag; }
 
 void StagNode::loadParameters() {
-    // Declare and load parameters
-    stag_library = this->declare_parameter<int>("stag_library", 15);
-    error_correction = this->declare_parameter<int>("error_correction", 7);
-    image_topic = this->declare_parameter<std::string>("image_topic", "image_raw");
-    camera_info_topic = this->declare_parameter<std::string>("camera_info_topic", "camera_info");
-    markers_topic = this->declare_parameter<std::string>("markers_topic", "stag_ros/markers");
-    markers_array_topic = this->declare_parameter<std::string>("markers_array_topic", "stag_ros/markers_array");
-    is_compressed = this->declare_parameter<bool>("is_compressed", false);
-    debug_images = this->declare_parameter<bool>("debug_images", true);
-    publish_tf = this->declare_parameter<bool>("publish_tf", false);
-    tag_tf_prefix = this->declare_parameter<std::string>("tag_tf_prefix", "STag_");
-    marker_size = this->declare_parameter<float>("marker_size", 0.18f);
+  // Declare and load parameters.
+  stag_library = this->declare_parameter<int>("stag_library", 15);
+  error_correction = this->declare_parameter<int>("error_correction", 7);
+  image_topic = this->declare_parameter<std::string>("image_topic", "image_raw");
+  camera_info_topic = this->declare_parameter<std::string>("camera_info_topic", "camera_info");
+  markers_topic = this->declare_parameter<std::string>("markers_topic", "stag_ros/markers");
+  markers_array_topic = this->declare_parameter<std::string>("markers_array_topic", "stag_ros/markers_array");
+  is_compressed = this->declare_parameter<bool>("is_compressed", false);
+  debug_images = this->declare_parameter<bool>("debug_images", true);
+  publish_tf = this->declare_parameter<bool>("publish_tf", false);
+  tag_tf_prefix = this->declare_parameter<std::string>("tag_tf_prefix", "STag_");
+  marker_size = this->declare_parameter<float>("marker_size", 0.18f);
+  config_file = this->declare_parameter<std::string>("config_file", "");
 
+  loadMarkerSizeConfig();
+}
+
+void StagNode::loadMarkerSizeConfig() {
+  marker_sizes_by_id.clear();
+  if (config_file.empty()) {
+    return;
+  }
+
+  std::filesystem::path config_path(config_file);
+  if (!config_path.is_absolute()) {
+    const auto package_share =
+        std::filesystem::path(ament_index_cpp::get_package_share_directory("stag_detect"));
+    const auto package_relative_path = package_share / config_path;
+    if (std::filesystem::exists(package_relative_path)) {
+      config_path = package_relative_path;
+    } else {
+      config_path = std::filesystem::absolute(config_path);
+    }
+  }
+
+  try {
+    const YAML::Node config = YAML::LoadFile(config_path.string());
+    const YAML::Node markers = config["markers"];
+    if (!markers) {
+      RCLCPP_WARN(this->get_logger(),
+                  "Marker config file '%s' does not contain a 'markers' list. "
+                  "Using marker_size fallback.",
+                  config_path.c_str());
+      return;
+    }
+
+    for (const YAML::Node &marker : markers) {
+      if (!marker["id"] || !marker["size"]) {
+        RCLCPP_WARN(this->get_logger(),
+                    "Skipping marker entry without both 'id' and 'size' in '%s'.",
+                    config_path.c_str());
+        continue;
+      }
+
+      const int marker_id = marker["id"].as<int>();
+      const float configured_size = marker["size"].as<float>();
+      if (configured_size <= 0.0f) {
+        RCLCPP_WARN(this->get_logger(),
+                    "Skipping marker %d because configured size must be positive.",
+                    marker_id);
+        continue;
+      }
+
+      marker_sizes_by_id[marker_id] = configured_size;
+    }
+
+    if (const YAML::Node default_size = config["default_marker_size"]) {
+      const float configured_default_size = default_size.as<float>();
+      if (configured_default_size > 0.0f) {
+        marker_size = configured_default_size;
+      } else {
+        RCLCPP_WARN(this->get_logger(),
+                    "Ignoring non-positive default_marker_size in '%s'.",
+                    config_path.c_str());
+      }
+    }
+
+    RCLCPP_INFO(this->get_logger(),
+                "Loaded %zu marker size entries from '%s'. Default marker size is %.3f m.",
+                marker_sizes_by_id.size(), config_path.c_str(), marker_size);
+  } catch (const YAML::Exception &e) {
+    RCLCPP_ERROR(this->get_logger(),
+                 "Failed to parse marker config file '%s': %s",
+                 config_path.c_str(), e.what());
+  }
+}
+
+float StagNode::getMarkerSizeForId(int marker_id) const {
+  const auto marker_size_it = marker_sizes_by_id.find(marker_id);
+  if (marker_size_it != marker_sizes_by_id.end()) {
+    return marker_size_it->second;
+  }
+  return marker_size;
 }
 
 void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg) {
@@ -154,15 +237,16 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
             tag_image[ci + 1] = markers[i].corners[ci];
           }
 
-          float half_makrer_size = marker_size/2.0;
+          const float current_marker_size = getMarkerSizeForId(markers[i].id);
+          const float half_marker_size = current_marker_size / 2.0f;
           // Top left
-          tag_world[1] = cv::Point3d(-half_makrer_size, half_makrer_size, 0.0);
+          tag_world[1] = cv::Point3d(-half_marker_size, half_marker_size, 0.0);
           // Top right
-          tag_world[2] = cv::Point3d(half_makrer_size, half_makrer_size, 0.0);
+          tag_world[2] = cv::Point3d(half_marker_size, half_marker_size, 0.0);
           // Bottom right
-          tag_world[3] = cv::Point3d(half_makrer_size, -half_makrer_size, 0.0);
+          tag_world[3] = cv::Point3d(half_marker_size, -half_marker_size, 0.0);
           // Bottom left
-          tag_world[4] = cv::Point3d(-half_makrer_size, -half_makrer_size, 0.0);
+          tag_world[4] = cv::Point3d(-half_marker_size, -half_marker_size, 0.0);
 
 
           cv::Mat marker_pose = cv::Mat::zeros(3, 4, CV_64F);

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -113,7 +113,12 @@ void StagNode::loadParameters() {
 
 void StagNode::loadMarkerSizeConfig() {
   marker_sizes_by_id.clear();
+  logged_marker_size_ids.clear();
+  warned_missing_marker_ids.clear();
   if (config_file.empty()) {
+    RCLCPP_INFO(this->get_logger(),
+                "No marker config file provided. Using marker_size=%.3f m for all tags.",
+                marker_size);
     return;
   }
 
@@ -158,6 +163,9 @@ void StagNode::loadMarkerSizeConfig() {
       }
 
       marker_sizes_by_id[marker_id] = configured_size;
+      RCLCPP_INFO(this->get_logger(),
+                  "Configured marker %d size: %.3f m",
+                  marker_id, configured_size);
     }
 
     if (const YAML::Node default_size = config["default_marker_size"]) {
@@ -187,6 +195,25 @@ float StagNode::getMarkerSizeForId(int marker_id) const {
     return marker_size_it->second;
   }
   return marker_size;
+}
+
+void StagNode::logMarkerSizeSelection(
+    int marker_id, float marker_size_value, bool is_configured_size) {
+  if (logged_marker_size_ids.find(marker_id) != logged_marker_size_ids.end()) {
+    return;
+  }
+
+  if (is_configured_size) {
+    RCLCPP_INFO(this->get_logger(),
+                "Marker %d will use configured size %.3f m for pose estimation.",
+                marker_id, marker_size_value);
+  } else if (warned_missing_marker_ids.insert(marker_id).second) {
+    RCLCPP_WARN(this->get_logger(),
+                "Marker %d is not present in '%s'. Falling back to marker_size %.3f m.",
+                marker_id, config_file.c_str(), marker_size_value);
+  }
+
+  logged_marker_size_ids.insert(marker_id);
 }
 
 void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg) {
@@ -237,7 +264,10 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
             tag_image[ci + 1] = markers[i].corners[ci];
           }
 
+          const bool has_configured_size =
+              marker_sizes_by_id.find(markers[i].id) != marker_sizes_by_id.end();
           const float current_marker_size = getMarkerSizeForId(markers[i].id);
+          logMarkerSizeSelection(markers[i].id, current_marker_size, has_configured_size);
           const float half_marker_size = current_marker_size / 2.0f;
           // Top left
           tag_world[1] = cv::Point3d(-half_marker_size, half_marker_size, 0.0);

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -254,14 +254,11 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
 
       for (int i = 0; i < markers.size(); i++) {
 
-          std::vector<cv::Point2d> tag_image(5);
-          std::vector<cv::Point3d> tag_world(5);
-
-          tag_image[0] = markers[i].center;
-          tag_world[0] = cv::Point3d(0.0, 0.0, 0.0);
+          std::vector<cv::Point2d> tag_image(4);
+          std::vector<cv::Point3d> tag_world(4);
 
           for (size_t ci = 0; ci < 4; ++ci) {
-            tag_image[ci + 1] = markers[i].corners[ci];
+            tag_image[ci] = markers[i].corners[ci];
           }
 
           const bool has_configured_size =
@@ -270,13 +267,13 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
           logMarkerSizeSelection(markers[i].id, current_marker_size, has_configured_size);
           const float half_marker_size = current_marker_size / 2.0f;
           // Top left
-          tag_world[1] = cv::Point3d(-half_marker_size, half_marker_size, 0.0);
+          tag_world[0] = cv::Point3d(-half_marker_size, half_marker_size, 0.0);
           // Top right
-          tag_world[2] = cv::Point3d(half_marker_size, half_marker_size, 0.0);
+          tag_world[1] = cv::Point3d(half_marker_size, half_marker_size, 0.0);
           // Bottom right
-          tag_world[3] = cv::Point3d(half_marker_size, -half_marker_size, 0.0);
+          tag_world[2] = cv::Point3d(half_marker_size, -half_marker_size, 0.0);
           // Bottom left
-          tag_world[4] = cv::Point3d(-half_marker_size, -half_marker_size, 0.0);
+          tag_world[3] = cv::Point3d(-half_marker_size, -half_marker_size, 0.0);
 
 
           cv::Mat marker_pose = cv::Mat::zeros(3, 4, CV_64F);

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -94,7 +94,6 @@ StagNode::StagNode() : Node("stag_detect") {
 StagNode::~StagNode() { delete stag; }
 
 void StagNode::loadParameters() {
-  // Declare and load parameters.
   stag_library = this->declare_parameter<int>("stag_library", 15);
   error_correction = this->declare_parameter<int>("error_correction", 7);
   image_topic = this->declare_parameter<std::string>("image_topic", "image_raw");
@@ -107,135 +106,39 @@ void StagNode::loadParameters() {
   tag_tf_prefix = this->declare_parameter<std::string>("tag_tf_prefix", "STag_");
   marker_size = this->declare_parameter<float>("marker_size", 0.18f);
   config_file = this->declare_parameter<std::string>("config_file", "");
-  marker_config_loaded = false;
-
-  RCLCPP_INFO(this->get_logger(),
-              "Startup marker_size=%.3f m config_file='%s'",
-              marker_size, config_file.c_str());
 
   loadMarkerSizeConfig();
 }
 
-std::filesystem::path StagNode::resolveMarkerConfigPath() const {
-  const std::filesystem::path raw_path(config_file);
-  if (raw_path.is_absolute()) {
-    return raw_path;
-  }
-
-  const auto package_share =
-      std::filesystem::path(ament_index_cpp::get_package_share_directory("stag_detect"));
-  const auto cwd_candidate = std::filesystem::current_path() / raw_path;
-  if (std::filesystem::exists(cwd_candidate)) {
-    return cwd_candidate;
-  }
-
-  const auto package_candidate = package_share / raw_path;
-  if (std::filesystem::exists(package_candidate)) {
-    return package_candidate;
-  }
-
-  std::filesystem::path cfg_suffix;
-  bool found_cfg = false;
-  for (const auto &part : raw_path) {
-    const std::string segment = part.string();
-    if (segment == "cfg") {
-      found_cfg = true;
-    }
-    if (found_cfg) {
-      cfg_suffix /= part;
-    }
-  }
-
-  if (found_cfg) {
-    const auto cfg_candidate = package_share / cfg_suffix;
-    if (std::filesystem::exists(cfg_candidate)) {
-      return cfg_candidate;
-    }
-  }
-
-  return package_candidate;
-}
-
 void StagNode::loadMarkerSizeConfig() {
   marker_sizes_by_id.clear();
-  logged_marker_size_ids.clear();
-  warned_missing_marker_ids.clear();
-  marker_config_loaded = false;
   if (config_file.empty()) {
-    RCLCPP_INFO(this->get_logger(),
-                "No marker config file provided. Using marker_size=%.3f m for all tags.",
-                marker_size);
     return;
   }
 
-  const std::filesystem::path config_path = resolveMarkerConfigPath();
-
-  if (!std::filesystem::exists(config_path)) {
-    throw std::runtime_error(
-        "Marker config file '" + config_path.string() + "' does not exist.");
+  std::filesystem::path config_path(config_file);
+  if (!config_path.is_absolute()) {
+    const auto package_share =
+        std::filesystem::path(ament_index_cpp::get_package_share_directory("stag_detect"));
+    config_path = package_share / config_path;
   }
-
-  RCLCPP_INFO(this->get_logger(),
-              "Loading marker size config from '%s'.",
-              config_path.c_str());
 
   try {
     const YAML::Node config = YAML::LoadFile(config_path.string());
-    YAML::Node config_root = config;
-    if (config["stag_detect"] && config["stag_detect"]["ros__parameters"]) {
-      config_root = config["stag_detect"]["ros__parameters"];
+    if (const YAML::Node default_size = config["default_marker_size"]) {
+      marker_size = default_size.as<float>();
     }
 
-    const YAML::Node markers = config_root["markers"];
-    if (!markers) {
-      RCLCPP_WARN(this->get_logger(),
-                  "Marker config file '%s' does not contain a 'markers' list. "
-                  "Using marker_size fallback.",
-                  config_path.c_str());
-      return;
-    }
+    const YAML::Node markers = config["markers"];
+    if (!markers) return;
 
     for (const YAML::Node &marker : markers) {
-      if (!marker["id"] || !marker["size"]) {
-        RCLCPP_WARN(this->get_logger(),
-                    "Skipping marker entry without both 'id' and 'size' in '%s'.",
-                    config_path.c_str());
-        continue;
-      }
-
-      const int marker_id = marker["id"].as<int>();
-      const float configured_size = marker["size"].as<float>();
-      if (configured_size <= 0.0f) {
-        RCLCPP_WARN(this->get_logger(),
-                    "Skipping marker %d because configured size must be positive.",
-                    marker_id);
-        continue;
-      }
-
-      marker_sizes_by_id[marker_id] = configured_size;
-      RCLCPP_INFO(this->get_logger(),
-                  "Configured marker %d size: %.3f m",
-                  marker_id, configured_size);
+      marker_sizes_by_id[marker["id"].as<int>()] = marker["size"].as<float>();
     }
-
-    if (const YAML::Node default_size = config_root["default_marker_size"]) {
-      const float configured_default_size = default_size.as<float>();
-      if (configured_default_size > 0.0f) {
-        marker_size = configured_default_size;
-      } else {
-        RCLCPP_WARN(this->get_logger(),
-                    "Ignoring non-positive default_marker_size in '%s'.",
-                    config_path.c_str());
-      }
-    }
-
-    RCLCPP_INFO(this->get_logger(),
-                "Loaded %zu marker size entries from '%s'. Default marker size is %.3f m.",
-                marker_sizes_by_id.size(), config_path.c_str(), marker_size);
-    marker_config_loaded = true;
   } catch (const std::exception &e) {
-    throw std::runtime_error(
-        "Failed to load marker config file '" + config_path.string() + "': " + e.what());
+    RCLCPP_ERROR(this->get_logger(),
+                 "Failed to load marker config file '%s': %s",
+                 config_path.c_str(), e.what());
   }
 }
 
@@ -245,25 +148,6 @@ float StagNode::getMarkerSizeForId(int marker_id) const {
     return marker_size_it->second;
   }
   return marker_size;
-}
-
-void StagNode::logMarkerSizeSelection(
-    int marker_id, float marker_size_value, bool is_configured_size) {
-  if (logged_marker_size_ids.find(marker_id) != logged_marker_size_ids.end()) {
-    return;
-  }
-
-  if (is_configured_size) {
-    RCLCPP_INFO(this->get_logger(),
-                "Marker %d will use configured size %.3f m for pose estimation.",
-                marker_id, marker_size_value);
-  } else if (warned_missing_marker_ids.insert(marker_id).second) {
-    RCLCPP_WARN(this->get_logger(),
-                "Marker %d is not present in '%s'. Falling back to marker_size %.3f m.",
-                marker_id, config_file.c_str(), marker_size_value);
-  }
-
-  logged_marker_size_ids.insert(marker_id);
 }
 
 void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg) {
@@ -311,16 +195,7 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
             tag_image[ci] = markers[i].corners[ci];
           }
 
-          const bool has_configured_size =
-              marker_sizes_by_id.find(markers[i].id) != marker_sizes_by_id.end();
           const float current_marker_size = getMarkerSizeForId(markers[i].id);
-          if (!config_file.empty() && !marker_config_loaded) {
-            RCLCPP_ERROR(this->get_logger(),
-                         "Marker config '%s' was requested but not loaded. "
-                         "Pose estimation is falling back to marker_size.",
-                         config_file.c_str());
-          }
-          logMarkerSizeSelection(markers[i].id, current_marker_size, has_configured_size);
           const float half_marker_size = current_marker_size / 2.0f;
           // Top left
           tag_world[0] = cv::Point3d(-half_marker_size, half_marker_size, 0.0);
@@ -363,12 +238,6 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
 
       Common::publishTransform(transform_msg, markersPub, msg->header,
 			       tag_tf_prefix, std::to_string(markers[i].id), publish_tf, shared_from_this());
-
-      RCLCPP_INFO(
-          this->get_logger(),
-          "Published marker id=%d size=%.3f m position=(x=%.6f, y=%.6f, z=%.6f)",
-          markers[i].id, current_marker_size, transform_msg.translation.x,
-          transform_msg.translation.y, transform_msg.translation.z);
 
 
       vision_msgs::msg::Detection2D markerobj;

--- a/stag_detect/src/stag_ros/stag_detect.cpp
+++ b/stag_detect/src/stag_ros/stag_detect.cpp
@@ -107,14 +107,60 @@ void StagNode::loadParameters() {
   tag_tf_prefix = this->declare_parameter<std::string>("tag_tf_prefix", "STag_");
   marker_size = this->declare_parameter<float>("marker_size", 0.18f);
   config_file = this->declare_parameter<std::string>("config_file", "");
+  marker_config_loaded = false;
+
+  RCLCPP_INFO(this->get_logger(),
+              "Startup marker_size=%.3f m config_file='%s'",
+              marker_size, config_file.c_str());
 
   loadMarkerSizeConfig();
+}
+
+std::filesystem::path StagNode::resolveMarkerConfigPath() const {
+  const std::filesystem::path raw_path(config_file);
+  if (raw_path.is_absolute()) {
+    return raw_path;
+  }
+
+  const auto package_share =
+      std::filesystem::path(ament_index_cpp::get_package_share_directory("stag_detect"));
+  const auto cwd_candidate = std::filesystem::current_path() / raw_path;
+  if (std::filesystem::exists(cwd_candidate)) {
+    return cwd_candidate;
+  }
+
+  const auto package_candidate = package_share / raw_path;
+  if (std::filesystem::exists(package_candidate)) {
+    return package_candidate;
+  }
+
+  std::filesystem::path cfg_suffix;
+  bool found_cfg = false;
+  for (const auto &part : raw_path) {
+    const std::string segment = part.string();
+    if (segment == "cfg") {
+      found_cfg = true;
+    }
+    if (found_cfg) {
+      cfg_suffix /= part;
+    }
+  }
+
+  if (found_cfg) {
+    const auto cfg_candidate = package_share / cfg_suffix;
+    if (std::filesystem::exists(cfg_candidate)) {
+      return cfg_candidate;
+    }
+  }
+
+  return package_candidate;
 }
 
 void StagNode::loadMarkerSizeConfig() {
   marker_sizes_by_id.clear();
   logged_marker_size_ids.clear();
   warned_missing_marker_ids.clear();
+  marker_config_loaded = false;
   if (config_file.empty()) {
     RCLCPP_INFO(this->get_logger(),
                 "No marker config file provided. Using marker_size=%.3f m for all tags.",
@@ -122,23 +168,11 @@ void StagNode::loadMarkerSizeConfig() {
     return;
   }
 
-  std::filesystem::path config_path(config_file);
-  if (!config_path.is_absolute()) {
-    const auto package_share =
-        std::filesystem::path(ament_index_cpp::get_package_share_directory("stag_detect"));
-    const auto package_relative_path = package_share / config_path;
-    if (std::filesystem::exists(package_relative_path)) {
-      config_path = package_relative_path;
-    } else {
-      config_path = std::filesystem::absolute(config_path);
-    }
-  }
+  const std::filesystem::path config_path = resolveMarkerConfigPath();
 
   if (!std::filesystem::exists(config_path)) {
-    RCLCPP_ERROR(this->get_logger(),
-                 "Marker config file '%s' does not exist.",
-                 config_path.c_str());
-    return;
+    throw std::runtime_error(
+        "Marker config file '" + config_path.string() + "' does not exist.");
   }
 
   RCLCPP_INFO(this->get_logger(),
@@ -198,10 +232,10 @@ void StagNode::loadMarkerSizeConfig() {
     RCLCPP_INFO(this->get_logger(),
                 "Loaded %zu marker size entries from '%s'. Default marker size is %.3f m.",
                 marker_sizes_by_id.size(), config_path.c_str(), marker_size);
+    marker_config_loaded = true;
   } catch (const std::exception &e) {
-    RCLCPP_ERROR(this->get_logger(),
-                 "Failed to parse marker config file '%s': %s",
-                 config_path.c_str(), e.what());
+    throw std::runtime_error(
+        "Failed to load marker config file '" + config_path.string() + "': " + e.what());
   }
 }
 
@@ -280,6 +314,12 @@ void StagNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg)
           const bool has_configured_size =
               marker_sizes_by_id.find(markers[i].id) != marker_sizes_by_id.end();
           const float current_marker_size = getMarkerSizeForId(markers[i].id);
+          if (!config_file.empty() && !marker_config_loaded) {
+            RCLCPP_ERROR(this->get_logger(),
+                         "Marker config '%s' was requested but not loaded. "
+                         "Pose estimation is falling back to marker_size.",
+                         config_file.c_str());
+          }
           logMarkerSizeSelection(markers[i].id, current_marker_size, has_configured_size);
           const float half_marker_size = current_marker_size / 2.0f;
           // Top left


### PR DESCRIPTION
  This pull request adds support for using different physical sizes for different STag IDs.

  Previously, stag_detect assumed a single global marker_size for all detected markers. That worked only
  when every marker in the environment had the same printed size. With this change, the node can
  optionally load a YAML config file that maps marker IDs to sizes, and use the configured size for pose
  estimation on a per-marker basis.

  This allows mixed deployments such as:

  - larger markers for long-range detection
  - smaller markers for close-range detection

  Implementation summary:

  - adds a new config_file parameter to stag_detect
  - loads marker sizes from YAML at startup into an id -> size map
  - uses the configured size for each detected marker when building the marker’s 3D corner model before
    pose estimation
  - keeps marker_size as the fallback when a marker ID is not listed in the config
  - uses a square-marker PnP path for pose estimation

  Example config:

  default_marker_size: 0.175
  markers:
    - id: 0
      size: 0.175
    - id: 5
      size: 0.09
    - id: 6
      size: 0.09

  Example launch usage:

  ros2 launch stag_detect stag_detect.launch.py config_file:=/path/to/marker_sizes.yaml
